### PR TITLE
postgres timestamps should allow string|Date

### DIFF
--- a/src/dialects/postgres.ts
+++ b/src/dialects/postgres.ts
@@ -31,8 +31,8 @@ export class CodegenPostgresDialect extends CodegenDialect {
     numeric: 'number',
     oid: 'number',
     text: 'string',
-    timestamp: 'number',
-    timestamptz: 'number',
+    timestamp: 'number|string|Date',
+    timestamptz: 'number|string|Date',
   };
 
   instantiate(options: { connectionString: string; ssl: boolean }) {


### PR DESCRIPTION
Postgres driver allows to pass `ISO 8601` dates represented by a `string`, and can even take `Date` object as input as well.

Something like :

```
                await kyselyDb.insertInto("checkins").values({
                    id: uuid,
                    inserted_at: new Date(),
                    recorded_at: "2022-05-31T18:31:02Z",
                    recorded_by: "fcamblor",
                    year: 2022,
                    content: JSON.stringify(otherCheckinFields)
                })
```
