### PR TITLE
Implement  basic mysql support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "peerDependencies": {
     "better-sqlite3": "^7.5.3",
     "kysely": "^0.19.6",
-    "pg": "^8.7.3"
+    "pg": "^8.7.3",
+    "mysql2": "^2.3.3"
   },
   "peerDependenciesMeta": {
     "better-sqlite3": {

--- a/src/connection-string-parser.ts
+++ b/src/connection-string-parser.ts
@@ -63,14 +63,22 @@ export class CodegenConnectionStringParser {
     try {
       void new URL(connectionString);
     } catch {
-      throw new SyntaxError(`Invalid URL: '${connectionString}'`);
+      if (!connectionString.includes('Server')) {
+        throw new SyntaxError(`Invalid URL: '${connectionString}'`);
+      }
     }
 
+    let dialectName: CodegenDialectName = 'sqlite';
+    if (connectionString.includes('Server')) {
+      dialectName = 'mysql';
+    }
+
+    if (connectionString.startsWith('postgres://')) {
+      dialectName = 'postgres';
+    }
     return {
       connectionString,
-      dialectName: connectionString.startsWith('postgres://')
-        ? 'postgres'
-        : 'sqlite',
+      dialectName,
     };
   }
 }

--- a/src/dialect-manager.ts
+++ b/src/dialect-manager.ts
@@ -1,12 +1,15 @@
 import { CodegenDialect } from './dialect';
+import { CodegenMySqlDialect } from './dialects/mysql';
 import { CodegenPostgresDialect } from './dialects/postgres';
 import { CodegenSqliteDialect } from './dialects/sqlite';
 
-export type CodegenDialectName = 'postgres' | 'sqlite';
+export type CodegenDialectName = 'postgres' | 'sqlite' | 'mysql';
 
 export class CodegenDialectManager {
   getDialect(name: CodegenDialectName): CodegenDialect {
     switch (name) {
+      case 'mysql':
+        return new CodegenMySqlDialect();
       case 'postgres':
         return new CodegenPostgresDialect();
       default:

--- a/src/dialects/mysql.ts
+++ b/src/dialects/mysql.ts
@@ -1,0 +1,44 @@
+import { MysqlDialect } from 'kysely';
+import * as mysql from 'mysql2';
+import { CodegenDialect } from '../dialect';
+
+export class CodegenMySqlDialect extends CodegenDialect {
+  override readonly defaultType = 'string';
+  override schema = 'public';
+
+  override readonly types: Record<
+    string,
+    'string' | 'boolean' | 'number' | 'Date'
+  > = {
+    bit: 'boolean',
+    datetime: 'Date',
+    double: 'number',
+    int: 'number',
+    text: 'string',
+    varchar: 'string',
+  };
+
+  instantiate(options: { connectionString: string; ssl: boolean }) {
+    const parsedConnectionString: Record<string, string> = {};
+    options.connectionString.split(';').forEach((entry) => {
+      const [key, value] = entry.split('=');
+      if (key && value) {
+        parsedConnectionString[key] = value;
+      }
+    });
+
+    const mysqlConfigOptions: mysql.ConnectionOptions = {
+      database: parsedConnectionString.Database,
+      host: parsedConnectionString.Server,
+      password: parsedConnectionString.Pwd,
+      port: Number(parsedConnectionString.Port),
+      user: parsedConnectionString.Uid,
+    };
+
+    this.schema = mysqlConfigOptions.database || 'public';
+
+    return new MysqlDialect({
+      pool: mysql.createPool(mysqlConfigOptions),
+    });
+  }
+}


### PR DESCRIPTION
- This is a really awesome project with the only drawback being that it lacks mysql support. I cranked up a basic mysql support to meet my needs, but I share here in case you want to merge into your project. It is very basic but since it served my needs it might serve the community's as well.
- The main modification to be aware of is that in the DATABASE_URL environment variable I'm using a standard mysql with connection string with the port being specified as described in the second example in the [mysql docs](https://www.connectionstrings.com/mysql/). So the .env file would look something like this `DATABASE_URL="Server=myServerAddress;Port=1234;Database=myDataBase;Uid=myUsernamePwd=myPassword;"`
-
