### PR TITLE
Basic support for postgres schemas

### DIFF
--- a/src/dialect.ts
+++ b/src/dialect.ts
@@ -1,4 +1,5 @@
-import { Dialect } from 'kysely';
+import { Dialect, TableMetadata } from 'kysely';
+import { pascalCase } from './util';
 
 export abstract class CodegenDialect {
   /**
@@ -104,4 +105,18 @@ export abstract class CodegenDialect {
     connectionString: string;
     ssl: boolean;
   }): Dialect;
+
+  /**
+   * Returns the model name for the given table.
+   */
+  getModelName(table: TableMetadata): string {
+    return pascalCase(table.name);
+  }
+
+  /**
+   * Returns the name of the table in the exported `DB` interface.
+   */
+  getExportedTableName(table: TableMetadata): string {
+    return table.name;
+  }
 }

--- a/src/dialects/postgres.ts
+++ b/src/dialects/postgres.ts
@@ -1,6 +1,7 @@
-import { PostgresDialect } from 'kysely';
+import { PostgresDialect, TableMetadata } from 'kysely';
 import { Pool } from 'pg';
 import { CodegenDialect } from '../dialect';
+import { pascalCase } from '../util';
 
 export class CodegenPostgresDialect extends CodegenDialect {
   override readonly defaultType = 'string';
@@ -14,7 +15,6 @@ export class CodegenPostgresDialect extends CodegenDialect {
   override readonly imports = {
     IPostgresInterval: 'postgres-interval',
   };
-  override readonly schema = 'public';
   override readonly types = {
     bool: 'boolean',
     bytea: 'Buffer',
@@ -41,5 +41,21 @@ export class CodegenPostgresDialect extends CodegenDialect {
         ssl: options.ssl ? { rejectUnauthorized: false } : false,
       }),
     });
+  }
+
+  override getModelName(table: TableMetadata): string {
+    if (table.schema !== 'public') {
+      return pascalCase(`${table.schema}_${table.name}`);
+    }
+
+    return super.getModelName(table);
+  }
+
+  override getExportedTableName(table: TableMetadata): string {
+    if (table.schema !== 'public') {
+      return `${table.schema}.${table.name}`;
+    }
+
+    return super.getExportedTableName(table);
   }
 }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -49,12 +49,7 @@ export class CodegenSerializer {
         }
       }
 
-      let modelName = table.name
-        .split('_')
-        .map((word) => {
-          return word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase();
-        })
-        .join('');
+      let modelName = this.dialect.getModelName(table);
 
       if (modelNames.has(modelName)) {
         let suffix = 2;
@@ -105,7 +100,10 @@ export class CodegenSerializer {
         name: metadata.modelName,
       });
 
-      exports.push([metadata.name, metadata.modelName]);
+      exports.push([
+        this.dialect.getExportedTableName(metadata),
+        metadata.modelName,
+      ]);
     }
 
     return {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns a PascalCased string.
+ *
+ * @example
+ * ```ts
+ * pascalCase('foo_bar')
+ * // FooBar
+ * ```
+ */
+export function pascalCase(str: string): string {
+  return str
+    .split('_')
+    .map((word) => {
+      return word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join('');
+}


### PR DESCRIPTION
All table exports that are not in the public schema are prefixed with the schema name. This is the way Kysely is designed to work an "enumerable" amount of schemas.

The table/model naming logic is moved to the dialect since schemas in other dialects (like mysql) are very different and should be treated differently. Schemas in mysql are the same as databases in postgres.

Feel free to ask changes for anything and I'll gladly do it. I may have done things the way you wouldn't have and I may have misunderstood many things about the codebase.

closes #10