### PR TITLE
Use looser peer dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "better-sqlite3": "^7.6.2",
-    "kysely": "0.x",
+    "kysely": ">=0.19.12",
     "mysql2": "^2.3.3",
     "pg": "^8.7.3"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "better-sqlite3": "^7.6.2",
-    "kysely": "^0.19.12",
+    "kysely": "0.x",
     "mysql2": "^2.3.3",
     "pg": "^8.7.3"
   },


### PR DESCRIPTION
Unfortunately NPM is sort of unpredictable when it comes to peer deps. I ran into this same issue with the kysely-data-api package we maintain. Yarn allows the user to cleanly specify their version but npm is strict and duplicates the package potentially breaking things.