### PR TITLE
 feat: add `--ignore-pattern` CLI option

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "dotenv": "^16.0.1",
+    "micromatch": "^4.0.5",
     "minimist": "^1.2.6"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@robinblomberg/eslint-config-robinblomberg": "0.12.0",
     "@robinblomberg/prettier-config": "^0.1.2",
     "@types/better-sqlite3": "^7.5.0",
+    "@types/micromatch": "^4.0.2",
     "@types/minimist": "^1.2.2",
     "@types/node": "^18.6.1",
     "@types/pg": "^8.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ specifiers:
   '@robinblomberg/eslint-config-robinblomberg': 0.12.0
   '@robinblomberg/prettier-config': ^0.1.2
   '@types/better-sqlite3': ^7.5.0
+  '@types/micromatch': ^4.0.2
   '@types/minimist': ^1.2.2
   '@types/node': ^18.6.1
   '@types/pg': ^8.6.5
@@ -14,6 +15,7 @@ specifiers:
   dotenv: ^16.0.1
   eslint: ^8.20.0
   kysely: ^0.19.12
+  micromatch: ^4.0.5
   minimist: ^1.2.6
   mysql2: ^2.3.3
   pg: ^8.7.3
@@ -24,6 +26,7 @@ specifiers:
 dependencies:
   chalk: 4.1.2
   dotenv: 16.0.1
+  micromatch: 4.0.5
   minimist: 1.2.6
 
 devDependencies:
@@ -31,6 +34,7 @@ devDependencies:
   '@robinblomberg/eslint-config-robinblomberg': 0.12.0
   '@robinblomberg/prettier-config': 0.1.2
   '@types/better-sqlite3': 7.5.0
+  '@types/micromatch': 4.0.2
   '@types/minimist': 1.2.2
   '@types/node': 18.6.1
   '@types/pg': 8.6.5
@@ -450,12 +454,22 @@ packages:
       '@types/node': 18.6.1
     dev: true
 
+  /@types/braces/3.0.1:
+    resolution: {integrity: sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==}
+    dev: true
+
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/micromatch/4.0.2:
+    resolution: {integrity: sha512-oqXqVb0ci19GtH0vOA/U2TmHTcRY9kuZl4mqUxe0QmJAlIW13kzhuK5pi1i9+ngav8FjpSb9FVS/GE00GLX1VA==}
+    dependencies:
+      '@types/braces': 3.0.1
     dev: true
 
   /@types/minimist/1.2.2:
@@ -889,7 +903,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /browserslist/4.20.2:
     resolution: {integrity: sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==}
@@ -1612,7 +1625,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /find-up/2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
@@ -1922,7 +1934,6 @@ packages:
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-property/1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
@@ -2112,7 +2123,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
   /mimic-response/3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -2402,7 +2412,6 @@ packages:
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /pnpm/7.9.3:
     resolution: {integrity: sha512-0hpAD1vtILw0i9gTN4ffagnScWMW9/avfZIKllBUd++fAvCss+hVgPPDd0HS9XcOT675gid4H9esGkbLdaFy+w==}
@@ -2893,7 +2902,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,8 @@ const VALID_FLAGS = new Set([
   'dialect',
   'h',
   'help',
-  'ignore-pattern',
+  'ignore-schemas',
+  'ignore-tables',
   'log-level',
   'out-file',
   'print',
@@ -23,7 +24,8 @@ const VALID_FLAGS = new Set([
 export type CliOptions = {
   camelCase: boolean;
   dialectName: DialectName | undefined;
-  ignorePattern: string | undefined;
+  ignoreSchemas: string | undefined;
+  ignoreTables: string | undefined;
   logLevel: LogLevel;
   outFile: string;
   print: boolean;
@@ -90,7 +92,8 @@ export class Cli {
     const dialectName = argv.dialect as DialectName | undefined;
     const help =
       !!argv.h || !!argv.help || _.includes('-h') || _.includes('--help');
-    const ignorePattern = argv['ignore-pattern'] as string | undefined;
+    const ignoreSchemas = argv['ignore-schemas'] as string | undefined;
+    const ignoreTables = argv['ignore-tables'] as string | undefined;
     const logLevel = this.#getLogLevel(argv['log-level']);
     const outFile = (argv['out-file'] as string) ?? DEFAULT_OUT_FILE;
     const print = !!argv.print;
@@ -116,7 +119,8 @@ export class Cli {
           '  --camel-case       Use the Kysely CamelCasePlugin.',
           `  --dialect          Set the SQL dialect. (values: [${dialectValues}])`,
           '  --help, -h         Print this message.',
-          "  --ignore-pattern   Ignore tables matching the pattern. (example: '^_')",
+          "  --ignore-schemas   Ignore schemas matching the pattern. (example: '^_')",
+          "  --ignore-tables    Ignore tables matching the pattern. (example: '^_')",
           '  --log-level        Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)',
           `  --out-file         Set the file build path. (default: ${DEFAULT_OUT_FILE})`,
           '  --print            Print the generated output to the terminal.',
@@ -160,7 +164,8 @@ export class Cli {
     return {
       camelCase,
       dialectName,
-      ignorePattern,
+      ignoreSchemas,
+      ignoreTables,
       logLevel,
       outFile,
       print,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,8 +13,7 @@ const VALID_FLAGS = new Set([
   'dialect',
   'h',
   'help',
-  'ignore-schemas',
-  'ignore-tables',
+  'ignore-pattern',
   'log-level',
   'out-file',
   'print',
@@ -24,8 +23,7 @@ const VALID_FLAGS = new Set([
 export type CliOptions = {
   camelCase: boolean;
   dialectName: DialectName | undefined;
-  ignoreSchemas: string | undefined;
-  ignoreTables: string | undefined;
+  ignorePattern: string | undefined;
   logLevel: LogLevel;
   outFile: string;
   print: boolean;
@@ -92,8 +90,7 @@ export class Cli {
     const dialectName = argv.dialect as DialectName | undefined;
     const help =
       !!argv.h || !!argv.help || _.includes('-h') || _.includes('--help');
-    const ignoreSchemas = argv['ignore-schemas'] as string | undefined;
-    const ignoreTables = argv['ignore-tables'] as string | undefined;
+    const ignorePattern = argv['ignore-pattern'] as string | undefined;
     const logLevel = this.#getLogLevel(argv['log-level']);
     const outFile = (argv['out-file'] as string) ?? DEFAULT_OUT_FILE;
     const print = !!argv.print;
@@ -119,8 +116,7 @@ export class Cli {
           '  --camel-case       Use the Kysely CamelCasePlugin.',
           `  --dialect          Set the SQL dialect. (values: [${dialectValues}])`,
           '  --help, -h         Print this message.',
-          "  --ignore-schemas   Ignore schemas matching the pattern. (example: '^_')",
-          "  --ignore-tables    Ignore tables matching the pattern. (example: '^_')",
+          "  --ignore-pattern   Ignore tables matching the pattern. (example: '^_')",
           '  --log-level        Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)',
           `  --out-file         Set the file build path. (default: ${DEFAULT_OUT_FILE})`,
           '  --print            Print the generated output to the terminal.',
@@ -164,8 +160,7 @@ export class Cli {
     return {
       camelCase,
       dialectName,
-      ignoreSchemas,
-      ignoreTables,
+      ignorePattern,
       logLevel,
       outFile,
       print,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ const VALID_FLAGS = new Set([
   'dialect',
   'h',
   'help',
+  'ignore-pattern',
   'log-level',
   'out-file',
   'print',
@@ -22,6 +23,7 @@ const VALID_FLAGS = new Set([
 export type CliOptions = {
   camelCase: boolean;
   dialectName: DialectName | undefined;
+  ignorePattern: string | undefined;
   logLevel: LogLevel;
   outFile: string;
   print: boolean;
@@ -88,6 +90,7 @@ export class Cli {
     const dialectName = argv.dialect as DialectName | undefined;
     const help =
       !!argv.h || !!argv.help || _.includes('-h') || _.includes('--help');
+    const ignorePattern = argv['ignore-pattern'] as string | undefined;
     const logLevel = this.#getLogLevel(argv['log-level']);
     const outFile = (argv['out-file'] as string) ?? DEFAULT_OUT_FILE;
     const print = !!argv.print;
@@ -109,14 +112,15 @@ export class Cli {
           '',
           'kysely-codegen [options]',
           '',
-          '  --all         Display all options.',
-          '  --camel-case  Use the Kysely CamelCasePlugin.',
-          `  --dialect     Set the SQL dialect. (values: [${dialectValues}])`,
-          '  --help, -h    Print this message.',
-          '  --log-level   Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)',
-          `  --out-file    Set the file build path. (default: ${DEFAULT_OUT_FILE})`,
-          '  --print       Print the generated output to the terminal.',
-          '  --url         Set the database connection string URL. This may point to an environment variable. (default: env(DATABASE_URL))',
+          '  --all              Display all options.',
+          '  --camel-case       Use the Kysely CamelCasePlugin.',
+          `  --dialect          Set the SQL dialect. (values: [${dialectValues}])`,
+          '  --help, -h         Print this message.',
+          "  --ignore-pattern   Ignore tables matching the pattern. (example: '^_')",
+          '  --log-level        Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)',
+          `  --out-file         Set the file build path. (default: ${DEFAULT_OUT_FILE})`,
+          '  --print            Print the generated output to the terminal.',
+          '  --url              Set the database connection string URL. This may point to an environment variable. (default: env(DATABASE_URL))',
           '',
         );
 
@@ -153,7 +157,15 @@ export class Cli {
       }
     }
 
-    return { camelCase, dialectName, logLevel, outFile, print, url };
+    return {
+      camelCase,
+      dialectName,
+      ignorePattern,
+      logLevel,
+      outFile,
+      print,
+      url,
+    };
   }
 
   async run(argv: string[]) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,7 +116,7 @@ export class Cli {
           '  --camel-case       Use the Kysely CamelCasePlugin.',
           `  --dialect          Set the SQL dialect. (values: [${dialectValues}])`,
           '  --help, -h         Print this message.',
-          "  --ignore-pattern   Ignore tables matching the pattern, matching SCHEMA/TABLE in glob format. (example: '*/_*')",
+          '  --ignore-pattern   Ignore tables matching the pattern, matching SCHEMA/TABLE in glob format. (examples: *.table, schema.*, *._*)',
           '  --log-level        Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)',
           `  --out-file         Set the file build path. (default: ${DEFAULT_OUT_FILE})`,
           '  --print            Print the generated output to the terminal.',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,7 +116,7 @@ export class Cli {
           '  --camel-case       Use the Kysely CamelCasePlugin.',
           `  --dialect          Set the SQL dialect. (values: [${dialectValues}])`,
           '  --help, -h         Print this message.',
-          "  --ignore-pattern   Ignore tables matching the pattern. (example: '^_')",
+          "  --ignore-pattern   Ignore tables matching the pattern, matching SCHEMA/TABLE in glob format. (example: '*/_*')",
           '  --log-level        Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)',
           `  --out-file         Set the file build path. (default: ${DEFAULT_OUT_FILE})`,
           '  --print            Print the generated output to the terminal.',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,7 +116,7 @@ export class Cli {
           '  --camel-case       Use the Kysely CamelCasePlugin.',
           `  --dialect          Set the SQL dialect. (values: [${dialectValues}])`,
           '  --help, -h         Print this message.',
-          '  --ignore-pattern   Ignore tables matching the pattern, matching SCHEMA/TABLE in glob format. (examples: *.table, schema.*, *._*)',
+          '  --ignore-pattern   Ignore tables matching the pattern, matching "schema.table" in glob format. (examples: *.table, schema.*, *._*)',
           '  --log-level        Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)',
           `  --out-file         Set the file build path. (default: ${DEFAULT_OUT_FILE})`,
           '  --print            Print the generated output to the terminal.',

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -18,8 +18,7 @@ export type GeneratorOptions = {
 };
 
 export type GenerateOptions = {
-  ignoreSchemas?: string;
-  ignoreTables?: string;
+  ignorePattern?: string;
   outFile: string;
   print?: boolean;
 };
@@ -54,8 +53,7 @@ export class Generator {
     const tables = await this.introspector.introspect({
       connectionString: this.connectionString,
       dialect: this.dialect,
-      ignoreSchemas: options.ignoreSchemas,
-      ignoreTables: options.ignoreTables,
+      ignorePattern: options.ignorePattern,
     });
 
     this.logger?.debug();

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -18,7 +18,8 @@ export type GeneratorOptions = {
 };
 
 export type GenerateOptions = {
-  ignorePattern?: string;
+  ignoreSchemas?: string;
+  ignoreTables?: string;
   outFile: string;
   print?: boolean;
 };
@@ -53,7 +54,8 @@ export class Generator {
     const tables = await this.introspector.introspect({
       connectionString: this.connectionString,
       dialect: this.dialect,
-      ignorePattern: options.ignorePattern,
+      ignoreSchemas: options.ignoreSchemas,
+      ignoreTables: options.ignoreTables,
     });
 
     this.logger?.debug();

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -18,6 +18,7 @@ export type GeneratorOptions = {
 };
 
 export type GenerateOptions = {
+  ignorePattern?: string;
   outFile: string;
   print?: boolean;
 };
@@ -52,6 +53,7 @@ export class Generator {
     const tables = await this.introspector.introspect({
       connectionString: this.connectionString,
       dialect: this.dialect,
+      ignorePattern: options.ignorePattern,
     });
 
     this.logger?.debug();

--- a/src/introspector.ts
+++ b/src/introspector.ts
@@ -8,7 +8,8 @@ export type CreateKyselyOptions = IntrospectOptions & {
 export type IntrospectOptions = {
   connectionString: string;
   dialect: Dialect;
-  ignorePattern?: string;
+  ignoreSchemas?: string;
+  ignoreTables?: string;
 };
 
 /**
@@ -48,9 +49,18 @@ export class Introspector {
       }
     }
 
-    if (options.ignorePattern) {
-      const ignorePattern = new RegExp(options.ignorePattern);
-      tables = tables.filter((table) => !ignorePattern.test(table.name));
+    if (options.ignoreSchemas) {
+      const ignorePattern = new RegExp(options.ignoreSchemas);
+      tables = tables.filter((table) => {
+        return table.schema ? !ignorePattern.test(table.schema) : true;
+      });
+    }
+
+    if (options.ignoreTables) {
+      const ignorePattern = new RegExp(options.ignoreTables);
+      tables = tables.filter((table) => {
+        return !ignorePattern.test(table.name);
+      });
     }
 
     return tables;

--- a/src/introspector.ts
+++ b/src/introspector.ts
@@ -8,8 +8,7 @@ export type CreateKyselyOptions = IntrospectOptions & {
 export type IntrospectOptions = {
   connectionString: string;
   dialect: Dialect;
-  ignoreSchemas?: string;
-  ignoreTables?: string;
+  ignorePattern?: string;
 };
 
 /**
@@ -49,18 +48,9 @@ export class Introspector {
       }
     }
 
-    if (options.ignoreSchemas) {
-      const ignorePattern = new RegExp(options.ignoreSchemas);
-      tables = tables.filter((table) => {
-        return table.schema ? !ignorePattern.test(table.schema) : true;
-      });
-    }
-
-    if (options.ignoreTables) {
-      const ignorePattern = new RegExp(options.ignoreTables);
-      tables = tables.filter((table) => {
-        return !ignorePattern.test(table.name);
-      });
+    if (options.ignorePattern) {
+      const ignorePattern = new RegExp(options.ignorePattern);
+      tables = tables.filter((table) => !ignorePattern.test(table.name));
     }
 
     return tables;

--- a/src/introspector.ts
+++ b/src/introspector.ts
@@ -1,4 +1,5 @@
 import { Kysely, TableMetadata } from 'kysely';
+import { isMatch } from 'micromatch';
 import { Dialect } from './dialect';
 
 export type CreateKyselyOptions = IntrospectOptions & {
@@ -49,8 +50,13 @@ export class Introspector {
     }
 
     if (options.ignorePattern) {
-      const ignorePattern = new RegExp(options.ignorePattern);
-      tables = tables.filter((table) => !ignorePattern.test(table.name));
+      tables = tables.filter(
+        (table) =>
+          !isMatch(
+            table.schema ? `${table.schema}/${table.name}` : table.name,
+            options.ignorePattern!,
+          ),
+      );
     }
 
     return tables;

--- a/src/introspector.ts
+++ b/src/introspector.ts
@@ -8,6 +8,7 @@ export type CreateKyselyOptions = IntrospectOptions & {
 export type IntrospectOptions = {
   connectionString: string;
   dialect: Dialect;
+  ignorePattern?: string;
 };
 
 /**
@@ -45,6 +46,11 @@ export class Introspector {
           throw error;
         }
       }
+    }
+
+    if (options.ignorePattern) {
+      const ignorePattern = new RegExp(options.ignorePattern);
+      tables = tables.filter((table) => !ignorePattern.test(table.name));
     }
 
     return tables;

--- a/src/introspector.ts
+++ b/src/introspector.ts
@@ -53,7 +53,7 @@ export class Introspector {
       tables = tables.filter(
         (table) =>
           !isMatch(
-            table.schema ? `${table.schema}/${table.name}` : table.name,
+            table.schema ? `${table.schema}.${table.name}` : table.name,
             options.ignorePattern!,
           ),
       );


### PR DESCRIPTION
Hey! This PR adds a new CLI option, `--ignore-pattern`, that allows users to ignore tables that match the pattern. For example:

```sh
# Ignore specific tables
kysely-codegen --ignore-pattern '^(secret_table|another_secret_table)$'

# Ignore table names starting with "_"
kysely-codegen --ignore-pattern '^_'
```

My particular use-case is I have auto-generated tables whose names start with an underscore. Currently when I run `kysely-codegen`, I need to then manually edit the generated file to remove whatever temporary tables existed at the time. With a CLI flag like this, I can ignore those tables and skip the manual edit step.

If you like this idea, let me know if the name works for you, I'm happy to adjust anything!