### PR TITLE
Fix CLI outputting --help on single line

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,7 +107,7 @@ export class Cli {
       const dialectValues = VALID_DIALECTS.join(', ');
 
       if (help) {
-        console.info(
+        console.info([
           '',
           'kysely-codegen [options]',
           '',
@@ -122,7 +122,7 @@ export class Cli {
           '  --print            Print the generated output to the terminal.',
           `  --url              Set the database connection string URL. This may point to an environment variable. (default: ${DEFAULT_URL})`,
           '',
-        );
+        ].join('\n'));
 
         process.exit(0);
       }


### PR DESCRIPTION
Fixed a regression in b749a677e6bfd7370559767e57e4c69746898f94 that removed newlines from `--help`'s output. This addresses #38.