### PR TITLE
feat: updating peerdependency version of better-sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "better-sqlite3": "^7.6.2",
+    "better-sqlite3": ">=7.6.2",
     "kysely": ">=0.19.12",
     "mysql2": "^2.3.3",
     "pg": "^8.7.3"


### PR DESCRIPTION
This will hopefully also handle the version 8 - as explained here - [Stack Overflow](https://stackoverflow.com/questions/47309598/make-your-npm-package-support-multiple-versions-of-peer-dependency)