### PR TITLE
Override type for boolean in SQLite adapter

### DIFF
--- a/src/dialects/sqlite/sqlite-adapter.ts
+++ b/src/dialects/sqlite/sqlite-adapter.ts
@@ -6,6 +6,7 @@ export class SqliteAdapter extends Adapter {
   override readonly scalars = {
     ANY: new IdentifierNode('unknown'),
     BLOB: new IdentifierNode('Buffer'),
+    BOOLEAN: new IdentifierNode('number'),
     INTEGER: new IdentifierNode('number'),
     NUMERIC: new IdentifierNode('number'),
     REAL: new IdentifierNode('number'),


### PR DESCRIPTION
First off thanks for building this amazing tool. I'm really enjoying using it. There's only one issue I've run into and it's regarding SQLite boolean columns. In SQLite booleans are numeric types and Better SQLite3 respects that, but Kysely Codegen annotates them as strings which is inaccurate. The changes made in this PR seem to be enough to fix the problem on my end. 

Here's a patch that solves the problem if it's useful to anyone before this gets merged.

```diff
diff --git a/node_modules/kysely-codegen/dist/dialects/sqlite/sqlite-adapter.js b/node_modules/kysely-codegen/dist/dialects/sqlite/sqlite-adapter.js
index bf7bf43..4e7059e 100644
--- a/node_modules/kysely-codegen/dist/dialects/sqlite/sqlite-adapter.js
+++ b/node_modules/kysely-codegen/dist/dialects/sqlite/sqlite-adapter.js
@@ -12,6 +12,7 @@ class SqliteAdapter extends adapter_1.Adapter {
             BLOB: new nodes_1.IdentifierNode('Buffer'),
             INTEGER: new nodes_1.IdentifierNode('number'),
             NUMERIC: new nodes_1.IdentifierNode('number'),
+            BOOLEAN: new nodes_1.IdentifierNode('number'),
             REAL: new nodes_1.IdentifierNode('number'),
             TEXT: new nodes_1.IdentifierNode('string'),
         };
```

Happy new year! 🎉 🎆 

