### PR TITLE
Fix test suite for case sensitive file systems

### DIFF
--- a/src/tests/e2e.test.ts
+++ b/src/tests/e2e.test.ts
@@ -43,7 +43,7 @@ const TESTS: Test[] = [
 const readDialectOutput = async (dialect: Dialect) => {
   const dialectName = dialect.constructor.name.slice(0, -'Dialect'.length);
   return await readFile(
-    join(__dirname, 'outputs', `${dialectName}.output.ts`),
+    join(__dirname, 'outputs', `${dialectName.toLowerCase()}.output.ts`),
     'utf-8',
   );
 };


### PR DESCRIPTION
I ran into a small hicup while setting up tests in my Linux machine, this PR should fix the issue.
I assumed that this fix would be desirable rather than renaming the files, but let me know if you rather have it the other way around.

## Before the PR
![Screenshot from 2023-01-03 10-29-58](https://user-images.githubusercontent.com/20662/210389587-fed62068-d5d7-4d27-a3ed-0dc11d466bf4.png)

## After the PR
![Screenshot from 2023-01-03 10-30-15](https://user-images.githubusercontent.com/20662/210389634-b573fce8-d3cd-4cd5-93c9-6d0b80164e91.png)

