### PR TITLE
Exit process as soon as CLI finishes

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 import { Cli } from '../cli';
 
-void new Cli().run(process.argv.slice(2));
+void new Cli().run(process.argv.slice(2)).then(() => process.exit(0));


### PR DESCRIPTION
Workaround for https://github.com/brianc/node-postgres/issues/2907.

Currently on a Postgres database that doesn't have SSL enabled, kysely-codegen will first attempt to connect with SSL, fail, and then proceed to connect without SSL. After that it finished successfully, but it hangs before exiting before some TCP connection from the SSL attempt is still open.

After the CLI finishes successfully, let's just close the process. This saves a few annoying seconds for me.