### PR TITLE
Fix: missing enum name schema on Postgres

### DIFF
--- a/src/dialects/postgres/postgres-introspector.ts
+++ b/src/dialects/postgres/postgres-introspector.ts
@@ -21,7 +21,7 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
           return {
             ...column,
             dataType: isArray ? column.dataType.slice(1) : column.dataType,
-            enumValues: enums.get(column.dataType),
+            enumValues: enums.get(`${column.dataTypeSchema}.${column.dataType}`),
             isArray,
           };
         }),


### PR DESCRIPTION
Enums are being generated as `string` without this change.