### PR TITLE
fix: remove parsing of connection string using `URL`

### DIFF
--- a/src/connection-string-parser.ts
+++ b/src/connection-string-parser.ts
@@ -83,14 +83,6 @@ export class ConnectionStringParser {
     const inferredDialectName =
       options.dialectName ?? this.#inferDialectName(connectionString);
 
-    if (inferredDialectName !== 'sqlite') {
-      try {
-        void new URL(connectionString);
-      } catch {
-        throw new SyntaxError(`Invalid URL: '${connectionString}'`);
-      }
-    }
-
     return {
       connectionString,
       inferredDialectName,


### PR DESCRIPTION
Reference: #65 

As @RobinBlomberg stated:

> Good find. Perhaps `void new URL(connectionString);` isn't a good enough check to see whether the connection string is valid. [...] Perhaps that check should be removed entirely, and we'll just let the connection fail if it's invalid.