### PR TITLE
Add mysql2@^3.0.0 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "better-sqlite3": ">=7.6.2",
     "kysely": ">=0.19.12",
-    "mysql2": "^2.3.3",
+    "mysql2": "^2.3.3,^3.0.0",
     "pg": "^8.8.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
kysely-codegen works well with `mysql2@^3.0.0`, so this PR adds it to peer dependency to remove annoying incorrect peer dependency warnings.