### PR TITLE
Handle tables with hyphens in their name

### DIFF
--- a/src/collections/symbol-collection.ts
+++ b/src/collections/symbol-collection.ts
@@ -57,7 +57,7 @@ export class SymbolCollection {
     }
 
     const symbolNames = new Set(Object.values(this.symbolNames));
-    symbolName = toPascalCase(id.replace(/\./g, '_').replace(/-/g, '_'));
+    symbolName = toPascalCase(id.replace(/[^a-zA-Z$_0-9]/g, '_');
 
     if (symbolNames.has(symbolName)) {
       let suffix = 2;

--- a/src/collections/symbol-collection.ts
+++ b/src/collections/symbol-collection.ts
@@ -57,7 +57,7 @@ export class SymbolCollection {
     }
 
     const symbolNames = new Set(Object.values(this.symbolNames));
-    symbolName = toPascalCase(id.replace(/\./g, '_'));
+    symbolName = toPascalCase(id.replace(/\./g, '_').replace(/-/g, '_'));
 
     if (symbolNames.has(symbolName)) {
       let suffix = 2;


### PR DESCRIPTION
Currently, tables with hyphens in their name generate interfaces with hyphens in their name.
This is handled together with table names with periods in them. 