### PR TITLE
add license to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kysely-codegen",
   "version": "0.10.0",
   "author": "Robin Blomberg",
+  "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
Hey 👋 

The library is listed as `license: none` on npmjs.com.