### PR TITLE
feat: support libsql/sqld

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm install --save-dev kysely-codegen
 npm install kysely pg
 npm install kysely mysql2
 npm install kysely better-sqlite3
+npm install @libsql/kysely-libsql
 ```
 
 ## Generating type definitions
@@ -32,6 +33,9 @@ DATABASE_URL=mysql://username:password@yourdomain.com/database
 
 # SQLite
 DATABASE_URL=C:/Program Files/sqlite3/db
+
+# LibSQL
+DATABASE_URL=libsql://token@host:port/dabase
 ```
 
 > If you're using PlanetScale, make sure the url contains an SSL query string parameter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,9 @@ services:
     restart: always
     ports:
       - 5433:5432
+  kysely_codegen_libsql:
+    container_name: kysely_codegen_libsql
+    image: ghcr.io/libsql/sqld:latest
+    restart: always
+    ports:
+      - 8080:8080

--- a/package.json
+++ b/package.json
@@ -51,12 +51,16 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
+    "@libsql/kysely-libsql": "^0.3.0",
     "better-sqlite3": ">=7.6.2",
     "kysely": ">=0.19.12",
     "mysql2": "^2.3.3 || ^3.0.0",
     "pg": "^8.8.0"
   },
   "peerDependenciesMeta": {
+    "@libsql/kysely-libsql": {
+      "optional": true
+    },
     "better-sqlite3": {
       "optional": true
     },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ export type CliOptions = {
   url: string;
 };
 
-export type LogLevelName = typeof LOG_LEVEL_NAMES[number];
+export type LogLevelName = (typeof LOG_LEVEL_NAMES)[number];
 
 /**
  * Creates a kysely-codegen command-line interface.

--- a/src/connection-string-parser.ts
+++ b/src/connection-string-parser.ts
@@ -34,6 +34,10 @@ export class ConnectionStringParser {
       return 'mysql';
     }
 
+    if (connectionString.startsWith('libsql://')) {
+      return 'libsql';
+    }
+
     return 'sqlite';
   }
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -21,4 +21,4 @@ export const LOG_LEVEL_NAMES = [
   'debug',
 ] as const;
 
-export const VALID_DIALECTS = ['mysql', 'postgres', 'sqlite'];
+export const VALID_DIALECTS = ['mysql', 'postgres', 'sqlite', 'libsql'];

--- a/src/dialect-manager.ts
+++ b/src/dialect-manager.ts
@@ -1,7 +1,12 @@
 import { Dialect } from './dialect';
-import { MysqlDialect, PostgresDialect, SqliteDialect } from './dialects';
+import {
+  LibSqlDialect,
+  MysqlDialect,
+  PostgresDialect,
+  SqliteDialect,
+} from './dialects';
 
-export type DialectName = 'mysql' | 'postgres' | 'sqlite';
+export type DialectName = 'mysql' | 'postgres' | 'sqlite' | 'libsql';
 
 /**
  * Returns a dialect instance for a pre-defined dialect name.
@@ -13,6 +18,8 @@ export class DialectManager {
         return new MysqlDialect();
       case 'postgres':
         return new PostgresDialect();
+      case 'libsql':
+        return new LibSqlDialect();
       default:
         return new SqliteDialect();
     }

--- a/src/dialects/index.ts
+++ b/src/dialects/index.ts
@@ -1,3 +1,4 @@
+export * from './libsql';
 export * from './mysql';
 export * from './postgres';
 export * from './sqlite';

--- a/src/dialects/libsql/index.ts
+++ b/src/dialects/libsql/index.ts
@@ -1,0 +1,2 @@
+export * from './libsql-adapter';
+export * from './libsql-dialect';

--- a/src/dialects/libsql/libsql-adapter.ts
+++ b/src/dialects/libsql/libsql-adapter.ts
@@ -1,0 +1,3 @@
+import { SqliteAdapter } from '../sqlite/sqlite-adapter';
+
+export class LibsqlAdapter extends SqliteAdapter {}

--- a/src/dialects/libsql/libsql-dialect.ts
+++ b/src/dialects/libsql/libsql-dialect.ts
@@ -1,0 +1,31 @@
+import { CreateKyselyDialectOptions, Dialect } from '../../dialect';
+import { LibsqlAdapter } from './libsql-adapter';
+import { SqliteIntrospector } from './libsql-introspector';
+
+export class LibSqlDialect extends Dialect {
+  readonly adapter = new LibsqlAdapter();
+  readonly introspector = new SqliteIntrospector();
+
+  async createKyselyDialect(options: CreateKyselyDialectOptions) {
+    const { LibsqlDialect } = await import('@libsql/kysely-libsql');
+
+    // libsql url are of the form libsql://token@host:port/db
+    const url = new URL(options.connectionString);
+
+    if (url.username) {
+      // the token takes the place of the username in the url
+      const token = url.username;
+
+      // remove the token from the url to get a 'normal' connection string
+      url.username = '';
+
+      return new LibsqlDialect({
+        authToken: token,
+        url: url.toString(),
+      });
+    }
+    return new LibsqlDialect({
+      url: options.connectionString,
+    });
+  }
+}

--- a/src/dialects/libsql/libsql-introspector.ts
+++ b/src/dialects/libsql/libsql-introspector.ts
@@ -1,0 +1,11 @@
+import { EnumCollection } from '../../collections';
+import { IntrospectOptions, Introspector } from '../../introspector';
+import { DatabaseMetadata } from '../../metadata';
+
+export class SqliteIntrospector extends Introspector<any> {
+  async introspect(options: IntrospectOptions<any>) {
+    const tables = await this.getTables(options);
+    const enums = new EnumCollection();
+    return new DatabaseMetadata(tables, enums);
+  }
+}

--- a/src/tests/connection-string-parser.test.ts
+++ b/src/tests/connection-string-parser.test.ts
@@ -65,5 +65,28 @@ export const testConnectionStringParser = () => {
         );
       });
     });
+
+    void describe('libsql', () => {
+      void it('should infer the correct dialect name', () => {
+        deepStrictEqual(
+          parser.parse({
+            connectionString: 'libsql://token@hostname:port/db',
+          }),
+          {
+            connectionString: 'libsql://token@hostname:port/db',
+            inferredDialectName: 'libsql',
+          },
+        );
+        deepStrictEqual(
+          parser.parse({
+            connectionString: 'libsql://hostname:port/db',
+          }),
+          {
+            connectionString: 'libsql://hostname:port/db',
+            inferredDialectName: 'libsql',
+          },
+        );
+      });
+    });
   });
 };

--- a/src/tests/e2e.test.ts
+++ b/src/tests/e2e.test.ts
@@ -3,7 +3,12 @@ import { readFile } from 'fs/promises';
 import { Kysely } from 'kysely';
 import { join } from 'path';
 import { Dialect } from '../dialect';
-import { MysqlDialect, PostgresDialect, SqliteDialect } from '../dialects';
+import {
+  LibSqlDialect,
+  MysqlDialect,
+  PostgresDialect,
+  SqliteDialect,
+} from '../dialects';
 import { Generator } from '../generator';
 import { Logger } from '../logger';
 import { migrate } from './fixtures';
@@ -36,6 +41,11 @@ const TESTS: Test[] = [
   {
     connectionString: ':memory:',
     dialect: new SqliteDialect(),
+    values: { false: 0, id: 1, true: 1 },
+  },
+  {
+    connectionString: 'libsql://localhost:8080?tls=0',
+    dialect: new LibSqlDialect(),
     values: { false: 0, id: 1, true: 1 },
   },
 ];

--- a/src/tests/outputs/libsql.output.ts
+++ b/src/tests/outputs/libsql.output.ts
@@ -1,0 +1,22 @@
+import type { ColumnType } from "kysely";
+
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+
+export interface FooBar {
+  false: number;
+  true: number;
+  id: Generated<number>;
+  userStatus: string | null;
+}
+
+export interface LibsqlWasmFuncTable {
+  name: string;
+  body: string | null;
+}
+
+export interface DB {
+  fooBar: FooBar;
+  libsqlWasmFuncTable: LibsqlWasmFuncTable;
+}


### PR DESCRIPTION
libsql is a fork of SQLite used by Turso.tech and others. Kysely dialect for it was contributed by https://github.com/libsql/kysely-libsql and this commit adds support for it kysely-codegen.

The alternative to leverage codegen is to pull the schema of your libsql database, put it into a sqlite file and then run the codegen.

cc @honzasp from https://github.com/libsql/kysely-libsql.