### PR TITLE
Add --env-file option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { Logger } from './logger';
 export type CliOptions = {
   camelCase: boolean;
   dialectName: DialectName | undefined;
+  envFile: string | undefined;
   excludePattern: string | undefined;
   includePattern: string | undefined;
   logLevel: LogLevel;
@@ -48,6 +49,7 @@ export class Cli {
         connectionString: options.url ?? DEFAULT_URL,
         dialectName: options.dialectName,
         logger,
+        envFile: options.envFile,
       });
 
     if (options.dialectName) {
@@ -143,6 +145,7 @@ export class Cli {
     const dialectName = argv.dialect as DialectName | undefined;
     const help =
       !!argv.h || !!argv.help || _.includes('-h') || _.includes('--help');
+    const envFile = argv['env-file'] as string | undefined;
     const excludePattern = argv['exclude-pattern'] as string | undefined;
     const includePattern = argv['include-pattern'] as string | undefined;
     const logLevel = this.#getLogLevel(argv['log-level']);
@@ -204,6 +207,7 @@ export class Cli {
     return {
       camelCase,
       dialectName,
+      envFile,
       excludePattern,
       includePattern,
       logLevel,

--- a/src/connection-string-parser.ts
+++ b/src/connection-string-parser.ts
@@ -13,6 +13,7 @@ export type ParseConnectionStringOptions = {
   connectionString: string;
   dialectName?: DialectName;
   logger?: Logger;
+  envFile?: string;
 };
 
 export type ParsedConnectionString = {
@@ -66,7 +67,9 @@ export class ConnectionStringParser {
         );
       }
 
-      loadEnv();
+      loadEnv({
+        path: options.envFile,
+      });
 
       options.logger?.info('Loaded environment variables from .env file.');
 

--- a/src/constants/flags.ts
+++ b/src/constants/flags.ts
@@ -24,6 +24,11 @@ export const FLAGS: Flag[] = [
   },
   {
     description:
+      'Load environment variables from a file relative to the current directory',
+    longName: 'env-file',
+  },
+  {
+    description:
       'Exclude tables matching the specified glob pattern. ' +
       '(examples: users, *.table, secrets.*, *._*)',
     longName: 'exclude-pattern',

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -10,6 +10,7 @@ export const testCli = () => {
   const DEFAULT_CLI_OPTIONS: CliOptions = {
     camelCase: false,
     dialectName: undefined,
+    envFile: undefined,
     excludePattern: undefined,
     includePattern: undefined,
     logLevel: DEFAULT_LOG_LEVEL,


### PR DESCRIPTION
Allows CLI users to define path to their dotenv file

Fixes #92