### PR TITLE
Update cli.ts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ export type LogLevelName = typeof LOG_LEVEL_NAMES[number];
  * Creates a kysely-codegen command-line interface.
  */
 export class Cli {
-  async #generate(options: CliOptions) {
+  async generate(options: CliOptions) {
     const camelCase = !!options.camelCase;
     const outFile = options.outFile;
     const excludePattern = options.excludePattern;
@@ -217,6 +217,6 @@ export class Cli {
 
   async run(argv: string[]) {
     const options = this.parseOptions(argv);
-    await this.#generate(options);
+    await this.generate(options);
   }
 }


### PR DESCRIPTION
Expose `generate/1`.
To run this programatically, you need to add a bunch of CLI args that are untyped. Exposing `generate`, makes sure `CliOptions` is a viable option.

This is especially crucial, as it makes an assumption `connection_string` (and/or backing ENV) is available. Using valid PGConfig like ` { database, host, user, password, port }` doesn't work. 

At the very least now you can run with it. 
```ts
    const dbConfigToConnectionString = (config: PoolConfig): string => {
      const { database, host, user, password, port } = config
      return `postgres://${user}:${password}@${host}:${port}/${database}`
    }
    ```