### PR TITLE
Update cli.ts

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -17,18 +17,18 @@ import {
 import { FLAGS } from './flags';
 
 export type CliOptions = {
-  camelCase: boolean;
-  dialectName: DialectName | undefined;
-  envFile: string | undefined;
-  excludePattern: string | undefined;
-  includePattern: string | undefined;
-  logLevel: LogLevel;
-  outFile: string | undefined;
-  print: boolean;
-  schema: string | undefined;
-  typeOnlyImports: boolean;
+  camelCase?: boolean;
+  dialectName?: DialectName | undefined;
+  envFile?: string | undefined;
+  excludePattern?: string | undefined;
+  includePattern?: string | undefined;
+  logLevel?: LogLevel;
+  outFile?: string | undefined;
+  print?: boolean;
+  schema?: string | undefined;
+  typeOnlyImports?: boolean;
   url: string;
-  verify: boolean | undefined;
+  verify?: boolean | undefined;
 };
 
 export type LogLevelName = typeof LOG_LEVEL_NAMES[number];


### PR DESCRIPTION
Making `CLIOptions` keys optionals, since not all arguments are required since they either default to something, or evaluated to booleans.



Keeping the `undefined` value since it has a different semantic meaning, where the value itself can be undefined, to satisfy `"exactOptionalPropertyTypes": true`
 
`url` is still required. 