### PR TITLE
Fix Postgres JSON type

### DIFF
--- a/src/dialects/postgres/postgres-adapter.ts
+++ b/src/dialects/postgres/postgres-adapter.ts
@@ -43,11 +43,7 @@ export class PostgresAdapter extends Adapter {
         new IdentifierNode('number'),
       ]),
     ),
-    Json: new ColumnType(
-      new IdentifierNode('JsonValue'),
-      new IdentifierNode('string'),
-      new IdentifierNode('string'),
-    ),
+    Json: JSON_VALUE_DEFINITION,
     JsonArray: JSON_ARRAY_DEFINITION,
     JsonObject: JSON_OBJECT_DEFINITION,
     JsonPrimitive: JSON_PRIMITIVE_DEFINITION,


### PR DESCRIPTION
The JSON type for Postgres was wrong, as it accepts a JSON itself directly via Kysely for insertion and update, no need to convert to string

Fixes #124 

Video showing result:


https://github.com/RobinBlomberg/kysely-codegen/assets/46006784/51862d76-cc47-43da-85d9-adf9a820b07a

