### PR TITLE
Fix Postgres JSON type

### DIFF
--- a/src/dialects/postgres/postgres-adapter.ts
+++ b/src/dialects/postgres/postgres-adapter.ts
@@ -9,6 +9,7 @@ import {
 import { Adapter } from '../../core';
 import {
   JSON_ARRAY_DEFINITION,
+  JSON_DEFINITION,
   JSON_OBJECT_DEFINITION,
   JSON_PRIMITIVE_DEFINITION,
   JSON_VALUE_DEFINITION,
@@ -43,7 +44,7 @@ export class PostgresAdapter extends Adapter {
         new IdentifierNode('number'),
       ]),
     ),
-    Json: JSON_VALUE_DEFINITION,
+    Json: JSON_DEFINITION,
     JsonArray: JSON_ARRAY_DEFINITION,
     JsonObject: JSON_OBJECT_DEFINITION,
     JsonPrimitive: JSON_PRIMITIVE_DEFINITION,

--- a/src/dialects/postgres/postgres-adapter.ts
+++ b/src/dialects/postgres/postgres-adapter.ts
@@ -43,11 +43,7 @@ export class PostgresAdapter extends Adapter {
         new IdentifierNode('number'),
       ]),
     ),
-    Json: new ColumnType(
-      new IdentifierNode('JsonValue'),
-      new IdentifierNode('string'),
-      new IdentifierNode('string'),
-    ),
+    Json: JSON_VALUE_DEFINITION,
     JsonArray: JSON_ARRAY_DEFINITION,
     JsonObject: JSON_OBJECT_DEFINITION,
     JsonPrimitive: JSON_PRIMITIVE_DEFINITION,

--- a/src/transformer/definitions.ts
+++ b/src/transformer/definitions.ts
@@ -79,4 +79,4 @@ export const JSON_VALUE_DEFINITION: DefinitionNode = new UnionExpressionNode([
   new IdentifierNode('JsonPrimitive'),
 ]);
 
-export const JSON_DEFINITION: DefinitionNode =new IdentifierNode('JsonValue');
+export const JSON_DEFINITION: DefinitionNode = new IdentifierNode('JsonValue');

--- a/src/transformer/definitions.ts
+++ b/src/transformer/definitions.ts
@@ -78,3 +78,5 @@ export const JSON_VALUE_DEFINITION: DefinitionNode = new UnionExpressionNode([
   new IdentifierNode('JsonObject'),
   new IdentifierNode('JsonPrimitive'),
 ]);
+
+export const JSON_DEFINITION: DefinitionNode =new IdentifierNode('JsonValue');


### PR DESCRIPTION
The JSON type for Postgres was wrong, as it accepts a JSON itself directly via Kysely for insertion and update, no need to convert to string

Fixes #124 

Video showing result:

https://github.com/RobinBlomberg/kysely-codegen/assets/46006784/51862d76-cc47-43da-85d9-adf9a820b07a