### PR TITLE
Make Postgres adapter set column types as JS number for Numeric PG type

### DIFF
--- a/src/dialects/postgres/postgres-adapter.ts
+++ b/src/dialects/postgres/postgres-adapter.ts
@@ -50,9 +50,9 @@ export class PostgresAdapter extends Adapter {
     JsonPrimitive: JSON_PRIMITIVE_DEFINITION,
     JsonValue: JSON_VALUE_DEFINITION,
     Numeric: new ColumnType(
-      new IdentifierNode('string'),
+      new IdentifierNode('number'),
       new UnionExpressionNode([
-        new IdentifierNode('string'),
+        new IdentifierNode('number'),
         new IdentifierNode('number'),
       ]),
     ),


### PR DESCRIPTION
See [this issue](https://github.com/RobinBlomberg/kysely-codegen/issues/109#issue-1947129362), have encountered the same behaviour. I'm not sure if this is intended behaviour or a bug, but I am using Postgres and my Select queries are incompatible with the generated schema for `NUMERIC` Postgres types. I can't see any reason to generate these types as below (maybe I'm missing something though):

`export type Numeric = ColumnType<string, number | string, number | number>`

I thought it should generate

`export type Numeric = ColumnType<number, number | number, number | number>`

I would assume that SELECTs, INSERTs and UPDATEs should all expect a Javascript `number` type to be the input/output type.

Many thanks for building out the project, it's proven really useful 🙂 
