### PR TITLE
Add a skip-domains flag for postgres

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -26,6 +26,7 @@ export type CliOptions = {
   outFile?: string | undefined;
   print?: boolean;
   schema?: string | undefined;
+  skipDomains?: boolean;
   typeOnlyImports?: boolean;
   url: string;
   verify?: boolean | undefined;
@@ -62,7 +63,9 @@ export class Cli {
       logger.info(`No dialect specified. Assuming '${inferredDialectName}'.`);
     }
 
-    const dialectManager = new DialectManager();
+    const dialectManager = new DialectManager({
+      skipDomains: options.skipDomains ?? false,
+    });
     const dialect = dialectManager.getDialect(
       options.dialectName ?? inferredDialectName,
     );

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -68,6 +68,11 @@ export const FLAGS: Flag[] = [
   },
   {
     description:
+      'Skip generating type information for postgres domains. (default: false)',
+    longName: 'skip-domains',
+  },
+  {
+    description:
       'Verify that the generated types are up-to-date. (default: false)',
     longName: 'verify',
   },

--- a/src/core/dialect-manager.ts
+++ b/src/core/dialect-manager.ts
@@ -16,10 +16,20 @@ export type DialectName =
   | 'postgres'
   | 'sqlite';
 
+export type DialectManagerOptions = {
+  skipDomains: boolean;
+};
+
 /**
  * Returns a dialect instance for a pre-defined dialect name.
  */
 export class DialectManager {
+  readonly #options: DialectManagerOptions;
+
+  constructor(opts: DialectManagerOptions) {
+    this.#options = opts;
+  }
+
   getDialect(name: DialectName): Dialect {
     switch (name) {
       case 'bun-sqlite':
@@ -31,7 +41,7 @@ export class DialectManager {
       case 'mysql':
         return new MysqlDialect();
       case 'postgres':
-        return new PostgresDialect();
+        return new PostgresDialect(this.#options);
       default:
         return new SqliteDialect();
     }

--- a/src/core/e2e.test.ts
+++ b/src/core/e2e.test.ts
@@ -35,7 +35,7 @@ const TESTS: Test[] = [
   },
   {
     connectionString: 'postgres://user:password@localhost:5433/database',
-    dialect: new PostgresDialect(),
+    dialect: new PostgresDialect({ skipDomains: false }),
     values: { false: false, id: 1, true: true },
   },
   {

--- a/src/dialects/postgres/postgres-dialect.ts
+++ b/src/dialects/postgres/postgres-dialect.ts
@@ -4,9 +4,20 @@ import { Dialect } from '../../core';
 import { PostgresAdapter } from './postgres-adapter';
 import { PostgresIntrospector } from './postgres-introspector';
 
+export type PostgresDialectOptions = {
+  skipDomains: boolean;
+};
+
 export class PostgresDialect extends Dialect {
+  readonly #options: PostgresDialectOptions;
   readonly adapter = new PostgresAdapter();
-  readonly introspector = new PostgresIntrospector(this.adapter);
+  readonly introspector;
+
+  constructor(opts: PostgresDialectOptions) {
+    super();
+    this.#options = opts;
+    this.introspector = new PostgresIntrospector(this.adapter, this.#options);
+  }
 
   async createKyselyDialect(options: CreateKyselyDialectOptions) {
     const { Pool } = await import('pg');

--- a/src/dialects/postgres/postgres-introspector.ts
+++ b/src/dialects/postgres/postgres-introspector.ts
@@ -17,12 +17,18 @@ type PostgresDomainInspector = {
   rootType: string;
 };
 
+export type PostgresIntrospectorOptions = {
+  skipDomains: boolean;
+};
+
 export class PostgresIntrospector extends Introspector<PostgresDB> {
   readonly adapter: PostgresAdapter;
+  readonly #options: PostgresIntrospectorOptions;
 
-  constructor(adapter: PostgresAdapter) {
+  constructor(adapter: PostgresAdapter, opts: PostgresIntrospectorOptions) {
     super();
     this.adapter = adapter;
+    this.#options = opts;
   }
 
   #createDatabaseMetadata(
@@ -94,6 +100,9 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
   }
 
   async #introspectDomains(db: Kysely<PostgresDB>) {
+    if (this.#options.skipDomains) {
+      return [];
+    }
     const result = await sql<PostgresDomainInspector>`
       with recursive domain_hierarchy as (
         select oid, typbasetype

--- a/src/serializer/serializer.test.ts
+++ b/src/serializer/serializer.test.ts
@@ -320,7 +320,7 @@ export const testSerializer = () => {
 
     void describe('serialize', () => {
       void it('should serialize Postgres JSON fields properly', () => {
-        const dialect = new PostgresDialect();
+        const dialect = new PostgresDialect({ skipDomains: false });
         const enums = new EnumCollection();
         const transformer = new Transformer();
 

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -32,7 +32,7 @@ export const testTransformer = () => {
     });
 
     const transform = (tables: TableMetadata[], camelCase: boolean) => {
-      const dialect = new PostgresDialect();
+      const dialect = new PostgresDialect({ skipDomains: false });
       const transformer = new Transformer();
       const metadata = new DatabaseMetadata(tables, enums);
       return transformer.transform({ camelCase, dialect, metadata });


### PR DESCRIPTION
Adds a new `--skip-domains` flag to skip domain introspection. This is useful for postgres compatible databases that don't support domains, like Materialize.

Fixes #112

I tried to follow the style in the project, and I ran the tests. Let me know if there is a better / different way to plumb the option through that you would prefer.