### PR TITLE
Set kysely-bun-worker as an optional peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "optional": false
     },
     "kysely-bun-worker": {
-      "optional": false
+      "optional": true
     },
     "mysql2": {
       "optional": true


### PR DESCRIPTION
Currently `kysely-bun-worker`, a package that provides a kysely sqlite dialect for bun, is set as `optional: false`. This causes unmet peer dependency warnings when installing packages if using a different dialect.

Example: yarn output
```
➤ YN0002: │ --@workspace:. doesn't provide kysely-bun-worker (pdcbd9), requested by kysely-codegen.
```