### PR TITLE
fix: domain flag is respected

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -66,7 +66,7 @@ export class Cli {
     }
 
     const dialectManager = new DialectManager({
-      skipDomains: !!options.domains,
+      domains: !!options.domains,
     });
     const dialect = dialectManager.getDialect(
       options.dialectName ?? inferredDialectName,

--- a/src/core/dialect-manager.ts
+++ b/src/core/dialect-manager.ts
@@ -17,7 +17,7 @@ export type DialectName =
   | 'sqlite';
 
 export type DialectManagerOptions = {
-  skipDomains?: boolean;
+  domains: boolean;
 };
 
 /**
@@ -26,7 +26,7 @@ export type DialectManagerOptions = {
 export class DialectManager {
   readonly #options: DialectManagerOptions;
 
-  constructor(options: DialectManagerOptions = {}) {
+  constructor(options: DialectManagerOptions = { domains: true }) {
     this.#options = options;
   }
 

--- a/src/dialects/postgres/postgres-dialect.ts
+++ b/src/dialects/postgres/postgres-dialect.ts
@@ -5,7 +5,7 @@ import { PostgresAdapter } from './postgres-adapter';
 import { PostgresIntrospector } from './postgres-introspector';
 
 export type PostgresDialectOptions = {
-  skipDomains?: boolean;
+  domains: boolean;
 };
 
 export class PostgresDialect extends Dialect {
@@ -13,7 +13,7 @@ export class PostgresDialect extends Dialect {
   readonly adapter = new PostgresAdapter();
   readonly introspector;
 
-  constructor(options: PostgresDialectOptions = {}) {
+  constructor(options: PostgresDialectOptions = { domains: true }) {
     super();
     this.#options = options;
     this.introspector = new PostgresIntrospector(this.adapter, this.#options);

--- a/src/dialects/postgres/postgres-introspector.ts
+++ b/src/dialects/postgres/postgres-introspector.ts
@@ -18,7 +18,7 @@ type PostgresDomainInspector = {
 };
 
 export type PostgresIntrospectorOptions = {
-  skipDomains?: boolean;
+  domains: boolean;
 };
 
 export class PostgresIntrospector extends Introspector<PostgresDB> {
@@ -27,7 +27,7 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
 
   constructor(
     adapter: PostgresAdapter,
-    options: PostgresIntrospectorOptions = {},
+    options: PostgresIntrospectorOptions = { domains: true },
   ) {
     super();
     this.adapter = adapter;
@@ -104,7 +104,7 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
   }
 
   async #introspectDomains(db: Kysely<PostgresDB>) {
-    if (this.#options.skipDomains) {
+    if (!this.#options.domains) {
       return [];
     }
 


### PR DESCRIPTION
The `--domains` and `--no-domains` flags ended up backwards when the [flag name was changed](https://github.com/RobinBlomberg/kysely-codegen/commit/fea605a51e64c0c97cebc261eeb6a2d6b94178b7#diff-25768f5853544984f9e0188641fe6d70f0e5d5245c9317d80be7d3d32a71dd44R67). I replaced the internal `skipDomains` option with a `domains` option to match to cli flag, to avoid this sort of confusion in the future.