### PR TITLE
fix flags in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,21 +99,21 @@ export interface DB {
 
 ## Include/exclude patterns
 
-You can choose which tables should be included during code generation by providing a glob pattern to the `--include` and `--exclude` flags. We use [micromatch](https://github.com/micromatch/micromatch) under the hood which provides advanced glob support. For instance, if you only want to include your public tables:
+You can choose which tables should be included during code generation by providing a glob pattern to the `--include-pattern` and `--exclude-pattern` flags. We use [micromatch](https://github.com/micromatch/micromatch) under the hood which provides advanced glob support. For instance, if you only want to include your public tables:
 
 ```bash
-kysely-codegen --include="public.*"
+kysely-codegen --include-pattern="public.*"
 ```
 
 You can also include only certain tables within a schema:
 
 ```bash
-kysely-codegen --include="public.+(user|post)"
+kysely-codegen --include-pattern="public.+(user|post)"
 ```
 
 Or exclude an entire class of tables:
 ```bash
-kysely-codegen --exclude="documents.*"
+kysely-codegen --exclude-pattern="documents.*"
 ```
 
 ## Help


### PR DESCRIPTION
On version `0.14.1` I was getting:
```
❯ pnpm kysely-codegen --include="public.*"
✗ Invalid flag: "include"
```

Here's the help output:
```
❯ pnpm kysely-codegen --help

kysely-codegen [options]

  --camel-case         Use the Kysely CamelCasePlugin.
  --dialect            Set the SQL dialect. (values: [postgres, mysql, sqlite, mssql, libsql, bun-sqlite])
  --env-file           Specify the path to an environment file to use.
  --exclude-pattern    Exclude tables matching the specified glob pattern. (examples: users, *.table, secrets.*, *._*)
  --help, -h           Print this message.
  --include-pattern    Only include tables matching the specified glob pattern. (examples: users, *.table, secrets.*, *._*)
  --log-level          Set the terminal log level. (values: [debug, info, warn, error, silent], default: warn)
  --no-domains         Skip generating types for PostgreSQL domains. (default: false)
  --out-file           Set the file build path. (default: /Users/jrhzor/code/bluewhale/interlinked/node_modules/kysely-codegen/dist/db.d.ts)
  --print              Print the generated output to the terminal.
  --runtime-enums      Generate runtime enums instead of string unions.
  --type-only-imports  Generate TypeScript 3.8+ `import type` syntax (default: true).
  --url                Set the database connection string URL. This may point to an environment variable. (default: env(DATABASE_URL))
  --schema             Set the default schema of the database connection.
  --verify             Verify that the generated types are up-to-date. (default: false)
```

So I updated the readme to use `include-pattern` instead of `include` and `exclude-pattern` instead of `exclude`.