### PR TITLE
Fixing bit IdentifierNode to be boolean instead of Buffer

### DIFF
--- a/src/dialects/mssql/mssql-adapter.ts
+++ b/src/dialects/mssql/mssql-adapter.ts
@@ -6,7 +6,7 @@ export class MssqlAdapter extends Adapter {
   override readonly scalars = {
     bigint: new IdentifierNode('number'),
     binary: new IdentifierNode('Buffer'),
-    bit: new IdentifierNode('Buffer'),
+    bit: new IdentifierNode('boolean'),
     char: new IdentifierNode('string'),
     date: new IdentifierNode('Date'),
     datetime: new IdentifierNode('Date'),


### PR DESCRIPTION
With the tedious package, MSSQL's `bit` data type is parsed out as a boolean JavaScript value. This change reflects that within the resulting codegen.