### PR TITLE
Adding an overrides property that allows for column types to be overridden

### DIFF
--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -5,6 +5,7 @@ import { performance } from 'perf_hooks';
 import type { Dialect, Logger } from '../core';
 import { DiffChecker } from '../core';
 import { Serializer } from '../serializer';
+import type { Overrides } from '../transformer';
 import { Transformer } from '../transformer';
 
 export type GenerateOptions = {
@@ -22,6 +23,7 @@ export type GenerateOptions = {
   transformer?: Transformer;
   typeOnlyImports?: boolean;
   verify?: boolean;
+  overrides?: Overrides;
 };
 
 /**
@@ -55,6 +57,7 @@ export class Generator {
       dialect: options.dialect,
       metadata,
       runtimeEnums: !!options.runtimeEnums,
+      overrides: options.overrides,
     });
 
     const serializer =

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -45,6 +45,11 @@ export const testTransformer = () => {
         dialect,
         metadata,
         runtimeEnums,
+        overrides: {
+          columns: {
+            'table.override': '{ test: string }',
+          },
+        },
       });
     };
 
@@ -71,6 +76,11 @@ export const testTransformer = () => {
                 dataType: 'text',
                 isArray: true,
                 name: 'texts',
+              }),
+              new ColumnMetadata({
+                dataType: 'text',
+                isArray: false,
+                name: 'override',
               }),
             ],
             name: 'table',
@@ -134,6 +144,10 @@ export const testTransformer = () => {
               new PropertyNode(
                 'texts',
                 new ArrayExpressionNode(new IdentifierNode('string')),
+              ),
+              new PropertyNode(
+                'override',
+                new IdentifierNode('{ test: string }'),
               ),
             ]),
           ),


### PR DESCRIPTION
This is somewhat related to #34, #75, and #30.

This follows the format in the JSON configuration issue (#34), so it should be adaptable to that. This does not implement any sort of TypeScript parsing. It will simply copy the value of the column name's override as an `IdentifierNode`. This will at least allow for simple type overrides, but I'm not entirely certain of what will and won't be supported with this.

I was also uncertain if the override in `#transformColumn` should truly override the type or if it should respect the `isNullable` or `isGenerated` parts of that. For now, I just have it as a true override which ignores those.

I have kept this as a property on the `Generator` class, and it is not included as a CLI option. I was not sure how this would be best implemented, so I left it alone for now and am just making it available through custom scripts.

I'm looking for some feedback on my prior uncertainties and if I'm missing anything glaringly obvious.
Thanks!