### PR TITLE
Column overrides

### DIFF
--- a/src/ast/expression-node.ts
+++ b/src/ast/expression-node.ts
@@ -6,6 +6,7 @@ import type { InferClauseNode } from './infer-clause-node';
 import type { LiteralNode } from './literal-node';
 import type { MappedTypeNode } from './mapped-type-node';
 import type { ObjectExpressionNode } from './object-expression-node';
+import type { RawExpressionNode } from './raw-expression-node';
 import type { UnionExpressionNode } from './union-expression-node';
 
 export type ExpressionNode =
@@ -17,4 +18,5 @@ export type ExpressionNode =
   | LiteralNode
   | MappedTypeNode
   | ObjectExpressionNode
+  | RawExpressionNode
   | UnionExpressionNode;

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -18,6 +18,7 @@ export * from './module-reference-node';
 export * from './node-type';
 export * from './object-expression-node';
 export * from './property-node';
+export * from './raw-expression-node';
 export * from './runtime-enum-declaration-node';
 export * from './statement-node';
 export * from './template-node';

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -12,6 +12,7 @@ export * from './import-clause-node';
 export * from './import-statement-node';
 export * from './infer-clause-node';
 export * from './interface-declaration-node';
+export * from './json-column-type-node';
 export * from './literal-node';
 export * from './mapped-type-node';
 export * from './module-reference-node';

--- a/src/ast/json-column-type-node.ts
+++ b/src/ast/json-column-type-node.ts
@@ -1,0 +1,13 @@
+import type { ExpressionNode } from './expression-node';
+import { GenericExpressionNode } from './generic-expression-node';
+import { IdentifierNode } from './identifier-node';
+
+export class JSONColumnType extends GenericExpressionNode {
+  constructor(selectType: ExpressionNode) {
+    super('ColumnType', [
+      selectType,
+      new IdentifierNode('string'),
+      new IdentifierNode('string'),
+    ]);
+  }
+}

--- a/src/ast/node-type.ts
+++ b/src/ast/node-type.ts
@@ -18,4 +18,5 @@ export const enum NodeType {
   TEMPLATE = 'Template',
   UNION_EXPRESSION = 'UnionExpression',
   VALUE = 'Value',
+  RAW_EXPRESSION = 'RawExpression',
 }

--- a/src/ast/raw-expression-node.ts
+++ b/src/ast/raw-expression-node.ts
@@ -1,0 +1,10 @@
+import { NodeType } from './node-type';
+
+export class RawExpressionNode {
+  readonly expression: string;
+  readonly type = NodeType.RAW_EXPRESSION;
+
+  constructor(expression: string) {
+    this.expression = expression;
+  }
+}

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -16,6 +16,7 @@ export type GenerateOptions = {
   includePattern?: string;
   logger?: Logger;
   outFile?: string;
+  overrides?: Overrides;
   print?: boolean;
   runtimeEnums?: boolean;
   schema?: string;
@@ -23,7 +24,6 @@ export type GenerateOptions = {
   transformer?: Transformer;
   typeOnlyImports?: boolean;
   verify?: boolean;
-  overrides?: Overrides;
 };
 
 /**

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -5,6 +5,7 @@ import { performance } from 'perf_hooks';
 import type { Dialect, Logger } from '../core';
 import { DiffChecker } from '../core';
 import { Serializer } from '../serializer';
+import type { Overrides } from '../transformer';
 import { Transformer } from '../transformer';
 
 export type GenerateOptions = {
@@ -22,6 +23,7 @@ export type GenerateOptions = {
   transformer?: Transformer;
   typeOnlyImports?: boolean;
   verify?: boolean;
+  overrides?: Overrides;
 };
 
 /**
@@ -55,6 +57,7 @@ export class Generator {
       dialect: options.dialect,
       metadata,
       runtimeEnums: !!options.runtimeEnums,
+      overrides: options.overrides,
     });
 
     const serializer =

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -14,6 +14,7 @@ import type {
   MappedTypeNode,
   ObjectExpressionNode,
   PropertyNode,
+  RawExpressionNode,
   RuntimeEnumDeclarationNode,
   StatementNode,
   UnionExpressionNode,
@@ -159,6 +160,8 @@ export class Serializer {
         return this.serializeMappedType(node);
       case NodeType.OBJECT_EXPRESSION:
         return this.serializeObjectExpression(node);
+      case NodeType.RAW_EXPRESSION:
+        return this.serializeRawExpression(node);
       case NodeType.UNION_EXPRESSION:
         return this.serializeUnionExpression(node);
     }
@@ -323,6 +326,10 @@ export class Serializer {
     data += ';\n';
 
     return data;
+  }
+
+  serializeRawExpression(node: RawExpressionNode) {
+    return node.expression;
   }
 
   serializeRuntimeEnum(node: RuntimeEnumDeclarationNode) {

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -45,6 +45,11 @@ export const testTransformer = () => {
         dialect,
         metadata,
         runtimeEnums,
+        overrides: {
+          columns: {
+            'table.override': '{ test: string }',
+          },
+        },
       });
     };
 
@@ -71,6 +76,11 @@ export const testTransformer = () => {
                 dataType: 'text',
                 isArray: true,
                 name: 'texts',
+              }),
+              new ColumnMetadata({
+                dataType: 'text',
+                isArray: false,
+                name: 'override',
               }),
             ],
             name: 'table',
@@ -134,6 +144,10 @@ export const testTransformer = () => {
               new PropertyNode(
                 'texts',
                 new ArrayExpressionNode(new IdentifierNode('string')),
+              ),
+              new PropertyNode(
+                'override',
+                new IdentifierNode('{ test: string }'),
               ),
             ]),
           ),

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -11,6 +11,7 @@ import {
   LiteralNode,
   ObjectExpressionNode,
   PropertyNode,
+  RawExpressionNode,
   RuntimeEnumDeclarationNode,
   UnionExpressionNode,
 } from '../ast';
@@ -147,7 +148,7 @@ export const testTransformer = () => {
               ),
               new PropertyNode(
                 'override',
-                new IdentifierNode('{ test: string }'),
+                new RawExpressionNode('{ test: string }'),
               ),
             ]),
           ),

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -49,6 +49,10 @@ export const testTransformer = () => {
         overrides: {
           columns: {
             'table.override': '{ test: string }',
+            'table.expression_override': new GenericExpressionNode(
+              'Generated',
+              [new IdentifierNode('boolean')],
+            ),
           },
         },
       });
@@ -82,6 +86,11 @@ export const testTransformer = () => {
                 dataType: 'text',
                 isArray: false,
                 name: 'override',
+              }),
+              new ColumnMetadata({
+                dataType: 'boolean',
+                isArray: false,
+                name: 'expression_override',
               }),
             ],
             name: 'table',
@@ -149,6 +158,12 @@ export const testTransformer = () => {
               new PropertyNode(
                 'override',
                 new RawExpressionNode('{ test: string }'),
+              ),
+              new PropertyNode(
+                'expression_override',
+                new GenericExpressionNode('Generated', [
+                  new IdentifierNode('boolean'),
+                ]),
               ),
             ]),
           ),

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -46,7 +46,17 @@ export type Overrides = {
   /**
    * Overrides a column's data type
    *
-   * @example { columns: { "<table_name>.<column_name>": "{ postalCode: string; street: string; city: string }" } }
+   * @example
+   * ```ts
+   * // Allows overriding of columns to be a type-safe JSON column
+   * {
+   *   columns: {
+   *     "<table_name>.<column_name>": new JSONColumnType(
+   *       new RawExpressionNode("{ postalCode: string; street: string; city: string }")
+   *     ),
+   *   }
+   * }
+   * ```
    */
   columns?: Record<string, ExpressionNode | string>;
 };

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -58,10 +58,10 @@ export type TransformContext = {
   enums: EnumCollection;
   imports: Imports;
   metadata: DatabaseMetadata;
+  overrides?: Overrides;
   runtimeEnums: boolean;
   scalars: Scalars;
   symbols: SymbolCollection;
-  overrides?: Overrides;
 };
 
 export type TransformOptions = {

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -12,6 +12,7 @@ import {
   NodeType,
   ObjectExpressionNode,
   PropertyNode,
+  RawExpressionNode,
   RuntimeEnumDeclarationNode,
   UnionExpressionNode,
 } from '../ast';
@@ -274,7 +275,7 @@ export class Transformer {
     const columnName = `${tableName}.${column.name}`;
     const columnOverride = context.overrides?.columns?.[columnName];
     if (columnOverride !== undefined) {
-      return new IdentifierNode(columnOverride);
+      return new RawExpressionNode(columnOverride);
     }
 
     let args = this.#transformColumnToArgs(column, context);

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -143,6 +143,9 @@ export class Transformer {
         }
 
         break;
+      case NodeType.RAW_EXPRESSION:
+        this.#collectSymbol(node.expression, context);
+        break;
       case NodeType.TEMPLATE:
         this.#collectSymbols(node.expression, context);
         break;

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -48,7 +48,7 @@ export type Overrides = {
    *
    * @example { columns: { "<table_name>.<column_name>": "{ postalCode: string; street: string; city: string }" } }
    */
-  columns?: Record<string, string>;
+  columns?: Record<string, ExpressionNode | string>;
 };
 
 export type TransformContext = {
@@ -275,7 +275,10 @@ export class Transformer {
     const columnName = `${tableName}.${column.name}`;
     const columnOverride = context.overrides?.columns?.[columnName];
     if (columnOverride !== undefined) {
-      return new RawExpressionNode(columnOverride);
+      if (typeof columnOverride === 'string') {
+        return new RawExpressionNode(columnOverride);
+      }
+      return columnOverride;
     }
 
     let args = this.#transformColumnToArgs(column, context);


### PR DESCRIPTION
This is somewhat related to #34, #75, and #30.

This follows the format in the JSON configuration issue (#34), so it should be adaptable to that. This does not implement any sort of TypeScript parsing. It will simply copy the value of the column name's override as an `IdentifierNode`. This will at least allow for simple type overrides, but I'm not entirely certain of what will and won't be supported with this.

I was also uncertain if the override in `#transformColumn` should truly override the type or if it should respect the `isNullable` or `isGenerated` parts of that. For now, I just have it as a true override which ignores those.

I have kept this as a property on the `Generator` class, and it is not included as a CLI option. I was not sure how this would be best implemented, so I left it alone for now and am just making it available through custom scripts.

I'm looking for some feedback on my prior uncertainties and if I'm missing anything glaringly obvious.
Thanks!