### PR TITLE
properly utilize ssl parameter for mssql dialect connection

### DIFF
--- a/src/dialects/mssql/mssql-dialect.ts
+++ b/src/dialects/mssql/mssql-dialect.ts
@@ -61,6 +61,7 @@ export class MssqlDialect extends Dialect {
               database,
               port,
               trustServerCertificate: true,
+              encrypt: options.ssl || true
             },
             server,
           });


### PR DESCRIPTION
#104
#128

During introspection, the ssl flag is sent using both true and false, attempting to create a connection to the database using encryption before attempting without.

Without this slight addition, the switching does not work and the encryption always defaults to true. 