### PR TITLE
Add String Option for PostgreSQL Interval Type in Upserts and Inserts

### DIFF
--- a/src/dialects/postgres/postgres-adapter.ts
+++ b/src/dialects/postgres/postgres-adapter.ts
@@ -42,6 +42,7 @@ export class PostgresAdapter extends Adapter {
       new UnionExpressionNode([
         new IdentifierNode('IPostgresInterval'),
         new IdentifierNode('number'),
+        new IdentifierNode('string'),
       ]),
     ),
     Json: JSON_DEFINITION,


### PR DESCRIPTION
This PR enhances the handling of PostgreSQL interval types in upsert and insert operations. Previously, the interval type was strictly managed as a number or IPostgresInterval. To improve flexibility and usability, this update allows the interval type to also be represented as a string. Using a number here seems incorrect, as I couldn't find such an option in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT), but I have kept this possibility to maintain backward compatibility.