### PR TITLE
Add --singular option, close 32

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "dotenv-expand": "^11.0.6",
     "git-diff": "^2.0.6",
     "micromatch": "^4.0.5",
-    "minimist": "^1.2.8"
+    "minimist": "^1.2.8",
+    "pluralize": "^8.0.0"
   },
   "devDependencies": {
     "@libsql/kysely-libsql": "^0.3.0",
@@ -57,6 +58,7 @@
     "@types/minimist": "^1.2.5",
     "@types/node": "^20.12.2",
     "@types/pg": "^8.11.4",
+    "@types/pluralize": "^0.0.33",
     "@types/tedious": "^4.0.14",
     "@typescript-eslint/parser": "^7.4.0",
     "better-sqlite3": "^9.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ devDependencies:
   '@types/pg':
     specifier: ^8.11.4
     version: 8.11.4
+  '@types/pluralize':
+    specifier: ^0.0.33
+    version: 0.0.33
   '@types/tedious':
     specifier: ^4.0.14
     version: 4.0.14
@@ -91,6 +94,9 @@ devDependencies:
   pg:
     specifier: ^8.11.4
     version: 8.11.4
+  pluralize:
+    specifier: ^8.0.0
+    version: 8.0.0
   pnpm:
     specifier: ^8.15.5
     version: 8.15.5
@@ -1161,6 +1167,10 @@ packages:
       '@types/node': 20.12.2
       pg-protocol: 1.6.0
       pg-types: 4.0.2
+    dev: true
+
+  /@types/pluralize@0.0.33:
+    resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
     dev: true
 
   /@types/readable-stream@4.0.10:

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -10,6 +10,7 @@ export const testCli = () => {
 
   const DEFAULT_CLI_OPTIONS: CliOptions = {
     camelCase: false,
+    singular: false,
     dialectName: undefined,
     domains: false,
     envFile: undefined,
@@ -37,6 +38,7 @@ export const testCli = () => {
       };
 
       assert(['--camel-case'], { camelCase: true });
+      assert(['--singular'], { singular: true });
       assert(['--dialect=mysql'], { dialectName: 'mysql' });
       assert(['--domains'], { domains: true });
       assert(['--no-domains'], { domains: false });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,6 +18,7 @@ import { FLAGS } from './flags';
 
 export type CliOptions = {
   camelCase?: boolean;
+  singular?: boolean;
   dialectName?: DialectName | undefined;
   domains?: boolean;
   envFile?: string | undefined;
@@ -41,6 +42,7 @@ export type LogLevelName = (typeof LOG_LEVEL_NAMES)[number];
 export class Cli {
   async generate(options: CliOptions) {
     const camelCase = !!options.camelCase;
+    const singular = !!options.singular;
     const excludePattern = options.excludePattern;
     const includePattern = options.includePattern;
     const outFile = options.outFile;
@@ -82,6 +84,7 @@ export class Cli {
 
     await generator.generate({
       camelCase,
+      singular,
       db,
       dialect,
       excludePattern,
@@ -155,6 +158,7 @@ export class Cli {
 
     const _: string[] = argv._;
     const camelCase = this.#parseBoolean(argv['camel-case']);
+    const singular = this.#parseBoolean(argv['singular']);
     const dialectName = argv.dialect;
     const domains = this.#parseBoolean(argv.domains);
     const envFile = argv['env-file'] as string | undefined;
@@ -230,6 +234,7 @@ export class Cli {
 
     return {
       camelCase,
+      singular,
       dialectName,
       domains,
       envFile,

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -12,6 +12,10 @@ export const FLAGS: Flag[] = [
     longName: 'camel-case',
   },
   {
+    description: 'Singularize entities.',
+    longName: 'singular',
+  },
+  {
     description: `Set the SQL dialect. (values: [${VALID_DIALECTS.join(
       ', ',
     )}])`,

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -9,6 +9,7 @@ import { Transformer } from '../transformer';
 
 export type GenerateOptions = {
   camelCase?: boolean;
+  singular?: boolean;
   db: Kysely<any>;
   dialect: Dialect;
   excludePattern?: string;
@@ -61,6 +62,7 @@ export class Generator {
       options.serializer ??
       new Serializer({
         camelCase: !!options.camelCase,
+        singular: !!options.singular,
         typeOnlyImports: options.typeOnlyImports,
       });
     const data = serializer.serialize(nodes);

--- a/src/serializer/serializer.test.ts
+++ b/src/serializer/serializer.test.ts
@@ -390,5 +390,40 @@ export const testSerializer = () => {
             '}',
         ));
     });
+
+    void describe('serialize - convert plural to singular', () => {
+      const dialect = new PostgresDialect();
+      const enums = new EnumCollection();
+      const transformer = new Transformer();
+      const singularSerializer = new Serializer({ singular: true });
+
+      const ast = transformer.transform({
+        camelCase: true,
+        dialect,
+        metadata: new DatabaseMetadata(
+          [
+            new TableMetadata({
+              columns: [
+                new ColumnMetadata({ dataType: 'varchar', name: 'username' }),
+              ],
+              name: 'users',
+              schema: 'public',
+            }),
+          ],
+          enums,
+        ),
+      });
+
+      strictEqual(
+        singularSerializer.serialize(ast),
+        'export interface User {\n' +
+          '  username: string;\n' +
+          '}\n' +
+          '\n' +
+          'export interface DB {\n' +
+          '  users: User;\n' +
+          '}\n',
+      );
+    });
   });
 };

--- a/src/serializer/serializer.test.ts
+++ b/src/serializer/serializer.test.ts
@@ -404,7 +404,11 @@ export const testSerializer = () => {
           [
             new TableMetadata({
               columns: [
-                new ColumnMetadata({ dataType: 'varchar', name: 'username' }),
+                new ColumnMetadata({
+                  dataType: 'varchar',
+                  name: 'username',
+                  hasDefaultValue: true,
+                }),
               ],
               name: 'users',
               schema: 'public',
@@ -416,8 +420,14 @@ export const testSerializer = () => {
 
       strictEqual(
         singularSerializer.serialize(ast),
-        'export interface User {\n' +
-          '  username: string;\n' +
+        'import type { ColumnType } from "kysely";\n' +
+          '\n' +
+          'export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>\n' +
+          '  ? ColumnType<S, I | undefined, U>\n' +
+          '  : ColumnType<T, T | undefined, T>;\n' +
+          '\n' +
+          'export interface User {\n' +
+          '  username: Generated<string>;\n' +
           '}\n' +
           '\n' +
           'export interface DB {\n' +

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -20,11 +20,13 @@ import type {
 } from '../ast';
 import { NodeType } from '../ast';
 import { toCamelCase } from '../transformer';
+import { singular } from 'pluralize';
 
 const IDENTIFIER_REGEXP = /^[$A-Z_a-z][\w$]*$/;
 
 export type SerializerOptions = {
   camelCase?: boolean;
+  singular?: boolean;
   typeOnlyImports?: boolean;
 };
 
@@ -33,10 +35,12 @@ export type SerializerOptions = {
  */
 export class Serializer {
   readonly camelCase: boolean;
+  readonly singular: boolean;
   readonly typeOnlyImports: boolean;
 
   constructor(options: SerializerOptions = {}) {
     this.camelCase = options.camelCase ?? false;
+    this.singular = options.singular ?? false;
     this.typeOnlyImports = options.typeOnlyImports ?? true;
   }
 
@@ -181,7 +185,7 @@ export class Serializer {
   serializeGenericExpression(node: GenericExpressionNode) {
     let data = '';
 
-    data += node.name;
+    data += this.singular ? singular(node.name) : node.name;
     data += '<';
 
     for (let i = 0; i < node.args.length; i++) {
@@ -198,7 +202,7 @@ export class Serializer {
   }
 
   serializeIdentifier(node: IdentifierNode) {
-    return node.name;
+    return this.singular ? singular(node.name) : node.name;
   }
 
   serializeImportClause(node: ImportClauseNode) {
@@ -256,7 +260,7 @@ export class Serializer {
     let data = '';
 
     data += 'interface ';
-    data += node.name;
+    data += this.singular ? singular(node.name) : node.name;
     data += ' ';
     data += this.serializeObjectExpression(node.body);
 

--- a/src/serializer/serializer.ts
+++ b/src/serializer/serializer.ts
@@ -185,7 +185,7 @@ export class Serializer {
   serializeGenericExpression(node: GenericExpressionNode) {
     let data = '';
 
-    data += this.singular ? singular(node.name) : node.name;
+    data += node.name;
     data += '<';
 
     for (let i = 0; i < node.args.length; i++) {
@@ -202,6 +202,10 @@ export class Serializer {
   }
 
   serializeIdentifier(node: IdentifierNode) {
+    // Prevent generic identifier such as `S` being trimmed
+    if (node.name.length < 2) {
+      return node.name;
+    }
     return this.singular ? singular(node.name) : node.name;
   }
 


### PR DESCRIPTION
Thank you for the fantastic tool!

As discussed on https://github.com/RobinBlomberg/kysely-codegen/issues/32, I've added option `--singular`.

# Examples

Given the schema:

```sql
CREATE TYPE user_status as ENUM ('ACTIVE', 'INACTIVE'); 

CREATE TABLE users (
  id UUID PRIMARY KEY DEFAULT gen_random_uuid (),
  status user_status NOT NULL
);
```

Run with `--singular`

```
pnpm kysely-codegen --singular
```

generates:

```ts
import type { ColumnType } from "kysely";

type UserStatus = 'ACTIVE' | 'INACTIVE'

export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
  ? ColumnType<S, I | undefined, U>
  : ColumnType<T, T | undefined, T>;

export interface User {
  id: Generated<string>;
  status: UserStatus;
}

export interface Database {
  users: User;
}
```

NOTE: It does not touch enum names and values.