### PR TITLE
Allow multiple default schemas

### DIFF
--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -27,7 +27,7 @@ describe(Cli.name, () => {
     print: false,
     runtimeEnums: false,
     runtimeEnumsStyle: undefined,
-    schema: undefined,
+    schema: [],
     singular: false,
     typeOnlyImports: true,
     url: DEFAULT_URL,
@@ -67,7 +67,8 @@ describe(Cli.name, () => {
       { overrides: { columns: { 'table.override': '{ foo: "bar" }' } } },
     );
     assert(['--print'], { outFile: undefined, print: true });
-    assert(['--schema=foo'], { schema: 'foo' });
+    assert(['--schema=foo'], { schema: ['foo'] });
+    assert(['--schema=foo', '--schema=bar'], { schema: ['foo', 'bar'] });
     assert(['--singular'], { singular: true });
     assert(['--type-only-imports'], { typeOnlyImports: true });
     assert(['--type-only-imports=false'], { typeOnlyImports: false });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -34,7 +34,7 @@ export type CliOptions = {
   print?: boolean;
   runtimeEnums?: boolean;
   runtimeEnumsStyle?: RuntimeEnumsStyle;
-  schema?: string;
+  schema: string[];
   singular?: boolean;
   typeOnlyImports?: boolean;
   url: string;
@@ -58,7 +58,7 @@ export class Cli {
     const print = !!options.print;
     const runtimeEnums = options.runtimeEnums;
     const runtimeEnumsStyle = options.runtimeEnumsStyle;
-    const schema = options.schema;
+    const schemas = options.schema;
     const singular = !!options.singular;
     const typeOnlyImports = options.typeOnlyImports;
     const verify = options.verify;
@@ -108,7 +108,7 @@ export class Cli {
       print,
       runtimeEnums,
       runtimeEnumsStyle,
-      schema,
+      schemas,
       singular,
       typeOnlyImports,
       verify,
@@ -164,6 +164,12 @@ export class Cli {
     return input === undefined ? undefined : String(input);
   }
 
+  #parseStringArray(input: any) {
+    if (input === undefined) return [];
+    if (!Array.isArray(input)) return [String(input)];
+    return input.map(String);
+  }
+
   #showHelp() {
     console.info(
       ['', 'kysely-codegen [options]', '', flagsString, ''].join('\n'),
@@ -195,7 +201,7 @@ export class Cli {
     const runtimeEnumsStyle = this.#parseRuntimeEnumsStyle(
       argv['runtime-enums-style'],
     );
-    const schema = this.#parseString(argv.schema);
+    const schema = this.#parseStringArray(argv.schema);
     const singular = this.#parseBoolean(argv.singular);
     const typeOnlyImports = this.#parseBoolean(
       argv['type-only-imports'] ?? true,

--- a/src/generator/adapter.ts
+++ b/src/generator/adapter.ts
@@ -14,7 +14,7 @@ export type Scalars = Record<string, ExpressionNode | undefined>;
  */
 export abstract class Adapter {
   readonly defaultScalar: ExpressionNode = new IdentifierNode('unknown');
-  readonly defaultSchema: string | null = null;
+  readonly defaultSchemas: string[] = [];
   readonly definitions: Definitions = {};
   readonly imports: Imports = {};
   readonly scalars: Scalars = {};

--- a/src/generator/dialects/postgres/postgres-adapter.ts
+++ b/src/generator/dialects/postgres/postgres-adapter.ts
@@ -25,7 +25,7 @@ export class PostgresAdapter extends Adapter {
   // PostgreSQL server as a string and node-postgres will pass it through without modifying it in
   // any way."
   override readonly defaultScalar = new IdentifierNode('string');
-  override readonly defaultSchema = 'public';
+  override readonly defaultSchemas = ['public'];
   override readonly definitions = {
     Circle: new ObjectExpressionNode([
       new PropertyNode('x', new IdentifierNode('number')),

--- a/src/generator/dialects/postgres/postgres-dialect.ts
+++ b/src/generator/dialects/postgres/postgres-dialect.ts
@@ -4,7 +4,7 @@ import type { GeneratorDialect } from '../../dialect';
 import { PostgresAdapter } from './postgres-adapter';
 
 type PostgresDialectOptions = {
-  defaultSchema?: string;
+  defaultSchema?: string[];
   domains?: boolean;
   numericParser?: NumericParser;
   partitions?: boolean;

--- a/src/generator/generator/generate.ts
+++ b/src/generator/generator/generate.ts
@@ -24,7 +24,7 @@ export type GenerateOptions = {
   print?: boolean;
   runtimeEnums?: boolean;
   runtimeEnumsStyle?: RuntimeEnumsStyle;
-  schema?: string;
+  schemas?: string[];
   serializer?: Serializer;
   singular?: boolean;
   typeOnlyImports?: boolean;
@@ -57,7 +57,7 @@ export const generate = async (options: GenerateOptions) => {
 
   const nodes = transform({
     camelCase: !!options.camelCase,
-    defaultSchema: options.schema,
+    defaultSchemas: options.schemas,
     dialect: options.dialect,
     metadata,
     overrides: options.overrides,

--- a/src/introspector/dialects/postgres/postgres-dialect.ts
+++ b/src/introspector/dialects/postgres/postgres-dialect.ts
@@ -5,7 +5,7 @@ import { DEFAULT_NUMERIC_PARSER, NumericParser } from './numeric-parser';
 import { PostgresIntrospector } from './postgres-introspector';
 
 type PostgresDialectOptions = {
-  defaultSchema?: string;
+  defaultSchemas?: string[];
   domains?: boolean;
   numericParser?: NumericParser;
   partitions?: boolean;
@@ -19,11 +19,12 @@ export class PostgresIntrospectorDialect extends IntrospectorDialect {
     super();
 
     this.introspector = new PostgresIntrospector({
-      defaultSchema: options?.defaultSchema,
+      defaultSchemas: options?.defaultSchemas,
       domains: options?.domains,
       partitions: options?.partitions,
     });
     this.options = {
+      defaultSchemas: options?.defaultSchemas,
       domains: options?.domains ?? true,
       numericParser: options?.numericParser ?? DEFAULT_NUMERIC_PARSER,
     };

--- a/src/introspector/dialects/postgres/postgres-introspector.ts
+++ b/src/introspector/dialects/postgres/postgres-introspector.ts
@@ -24,7 +24,7 @@ type TableReference = {
 };
 
 type PostgresIntrospectorOptions = {
-  defaultSchema?: string;
+  defaultSchemas?: string[];
   domains?: boolean;
   partitions?: boolean;
 };
@@ -36,7 +36,10 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
     super();
 
     this.options = {
-      defaultSchema: options?.defaultSchema ?? 'public',
+      defaultSchemas:
+        options?.defaultSchemas && options.defaultSchemas.length > 0
+          ? options.defaultSchemas
+          : ['public'],
       domains: options?.domains ?? true,
     };
   }
@@ -57,7 +60,7 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
         const columns = table.columns.map((column): ColumnMetadata => {
           const dataType = this.#getRootType(column, domains);
           const enumValues = enums.get(
-            `${column.dataTypeSchema ?? this.options.defaultSchema}.${dataType}`,
+            `${column.dataTypeSchema ?? this.options.defaultSchemas}.${dataType}`,
           );
           const isArray = dataType.startsWith('_');
 


### PR DESCRIPTION
Fixes https://github.com/RobinBlomberg/kysely-codegen/issues/155

This PR makes the `--schema` flag an array, so that you can specify it multiple times, which results in each of the listed schemas being unprefixed in the types. One obvious downside is that the relation names must all be unique, otherwise you will get type errors.


The way I'm planning to use this is by setting my search path to include several schemas, so that when tables are moved between schemas, we don't have to make code changes. This is important, because our app has to support 2 versions of the database at a time. Without this change, we have to add a conditional each time a relation promoted from one schema to another.

If this approach looks good, I'll add an example to the readme as well.