### PR TITLE
Fix for #196: Correctly pass the partition option to the Postgres inspector

### DIFF
--- a/src/introspector/dialects/postgres/postgres-introspector.ts
+++ b/src/introspector/dialects/postgres/postgres-introspector.ts
@@ -41,6 +41,7 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
           ? options.defaultSchemas
           : ['public'],
       domains: options?.domains ?? true,
+      partitions: options?.partitions ?? true,
     };
   }
 


### PR DESCRIPTION
See related issue #196. 

The option was not passed to the Postgres inspector. 