### PR TITLE
Allow PG Timestamp to accept string as selectType.

### DIFF
--- a/src/generator/dialects/postgres/postgres-adapter.ts
+++ b/src/generator/dialects/postgres/postgres-adapter.ts
@@ -65,7 +65,10 @@ export class PostgresAdapter extends Adapter {
       new PropertyNode('y', new IdentifierNode('number')),
     ]),
     Timestamp: new ColumnTypeNode(
-      new IdentifierNode('Date'),
+      new UnionExpressionNode([
+        new IdentifierNode('Date'),
+        new IdentifierNode('string'),
+      ]),
       new UnionExpressionNode([
         new IdentifierNode('Date'),
         new IdentifierNode('string'),


### PR DESCRIPTION
We're currently facing issues with the timestamps due to Date not considering microseconds, which would be fixed if the type is `string`.

Related issues: #194, #123, #177