### PR TITLE
feat: Add --date-parser flag to control Postgres DATE type

### DIFF
--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { describe, it } from 'vitest';
 import packageJson from '../../package.json';
 import { LogLevel } from '../generator/logger/log-level';
+import { DateParser, DEFAULT_DATE_PARSER } from '../introspector/dialects/postgres/date-parser';
 import { DEFAULT_NUMERIC_PARSER } from '../introspector/dialects/postgres/numeric-parser';
 import type { CliOptions } from './cli';
 import { Cli } from './cli';
@@ -14,6 +15,7 @@ describe(Cli.name, () => {
 
   const DEFAULT_CLI_OPTIONS: CliOptions = {
     camelCase: false,
+    dateParser: DEFAULT_DATE_PARSER,
     dialectName: undefined,
     domains: false,
     envFile: undefined,
@@ -52,6 +54,8 @@ describe(Cli.name, () => {
     };
 
     assert(['--camel-case'], { camelCase: true });
+    assert(['--date-parser=timestamp'], { dateParser: DateParser.TIMESTAMP });
+    assert(['--date-parser=string'], { dateParser: DateParser.STRING });
     assert(['--dialect=mysql'], { dialectName: 'mysql' });
     assert(['--domains'], { domains: true });
     assert(['--exclude-pattern=public._*'], { excludePattern: 'public._*' });

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -22,6 +22,12 @@ export const FLAGS = [
     longName: 'camel-case',
   },
   {
+    default: 'timestamp',
+    description: 'Specify which parser to use for PostgreSQL date values.',
+    longName: 'date-parser',
+    values: ['string', 'timestamp'],
+  },
+  {
     description: 'Set the SQL dialect.',
     longName: 'dialect',
     values: VALID_DIALECTS,

--- a/src/generator/dialect-manager.ts
+++ b/src/generator/dialect-manager.ts
@@ -1,3 +1,4 @@
+import type { DateParser } from '../introspector/dialects/postgres/date-parser';
 import type { NumericParser } from '../introspector/dialects/postgres/numeric-parser';
 import type { GeneratorDialect } from './dialect';
 import { KyselyBunSqliteDialect } from './dialects/kysely-bun-sqlite/kysely-bun-sqlite-dialect';
@@ -19,6 +20,7 @@ export type DialectName =
   | 'worker-bun-sqlite';
 
 type DialectManagerOptions = {
+  dateParser?: DateParser;
   domains?: boolean;
   numericParser?: NumericParser;
   partitions?: boolean;

--- a/src/generator/dialects/postgres/postgres-adapter.ts
+++ b/src/generator/dialects/postgres/postgres-adapter.ts
@@ -1,3 +1,4 @@
+import { DateParser } from '../../../introspector/dialects/postgres/date-parser';
 import { NumericParser } from '../../../introspector/dialects/postgres/numeric-parser';
 import { Adapter } from '../../adapter';
 import { ColumnTypeNode } from '../../ast/column-type-node';
@@ -15,6 +16,7 @@ import {
 } from '../../transformer/definitions';
 
 type PostgresAdapterOptions = {
+  dateParser?: DateParser;
   numericParser?: NumericParser;
 };
 
@@ -136,6 +138,12 @@ export class PostgresAdapter extends Adapter {
 
   constructor(options?: PostgresAdapterOptions) {
     super();
+
+    if (options?.dateParser === DateParser.STRING) {
+      this.scalars.date = new IdentifierNode('string');
+    } else {
+      this.scalars.date = new IdentifierNode('Timestamp');
+    }
 
     if (options?.numericParser === NumericParser.NUMBER) {
       this.definitions.Numeric = new ColumnTypeNode(

--- a/src/generator/dialects/postgres/postgres-dialect.ts
+++ b/src/generator/dialects/postgres/postgres-dialect.ts
@@ -1,9 +1,11 @@
+import type { DateParser } from '../../../introspector/dialects/postgres/date-parser';
 import type { NumericParser } from '../../../introspector/dialects/postgres/numeric-parser';
 import { PostgresIntrospectorDialect } from '../../../introspector/dialects/postgres/postgres-dialect';
 import type { GeneratorDialect } from '../../dialect';
 import { PostgresAdapter } from './postgres-adapter';
 
 type PostgresDialectOptions = {
+  dateParser?: DateParser;
   defaultSchemas?: string[];
   domains?: boolean;
   numericParser?: NumericParser;
@@ -12,14 +14,14 @@ type PostgresDialectOptions = {
 
 export class PostgresDialect
   extends PostgresIntrospectorDialect
-  implements GeneratorDialect
-{
+  implements GeneratorDialect {
   readonly adapter: PostgresAdapter;
 
   constructor(options?: PostgresDialectOptions) {
     super(options);
 
     this.adapter = new PostgresAdapter({
+      dateParser: this.options.dateParser,
       numericParser: this.options.numericParser,
     });
   }

--- a/src/generator/generator/generate.test.ts
+++ b/src/generator/generator/generate.test.ts
@@ -2,6 +2,7 @@ import { strictEqual } from 'assert';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { describe, test } from 'vitest';
+import { DateParser } from '../../introspector/dialects/postgres/date-parser';
 import { NumericParser } from '../../introspector/dialects/postgres/numeric-parser';
 import {
   addExtraColumn,
@@ -33,6 +34,7 @@ const TESTS: Test[] = [
   {
     connectionString: 'postgres://user:password@localhost:5433/database',
     dialect: new PostgresDialect({
+      dateParser: DateParser.TIMESTAMP,
       numericParser: NumericParser.NUMBER_OR_STRING,
     }),
   },

--- a/src/generator/generator/generate.ts
+++ b/src/generator/generator/generate.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import type { Kysely } from 'kysely';
 import { parse, relative, sep } from 'path';
 import { performance } from 'perf_hooks';
+import type { DateParser } from '../../introspector/dialects/postgres/date-parser';
 import type { NumericParser } from '../../introspector/dialects/postgres/numeric-parser';
 import type { GeneratorDialect } from '../dialect';
 import type { Logger } from '../logger/logger';
@@ -12,6 +13,7 @@ import { Serializer } from './serializer';
 
 export type GenerateOptions = {
   camelCase?: boolean;
+  dateParser?: DateParser;
   db: Kysely<any>;
   dialect: GeneratorDialect;
   excludePattern?: string;

--- a/src/generator/generator/snapshots/postgres-runtime-enums.snapshot.ts
+++ b/src/generator/generator/snapshots/postgres-runtime-enums.snapshot.ts
@@ -49,6 +49,7 @@ export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 export interface FooBar {
   array: string[] | null;
   childDomain: number | null;
+  date: string | null;
   defaultedNullablePosInt: Generated<number | null>;
   defaultedRequiredPosInt: Generated<number>;
   /**

--- a/src/generator/generator/snapshots/postgres.snapshot.ts
+++ b/src/generator/generator/snapshots/postgres.snapshot.ts
@@ -43,6 +43,7 @@ export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 export interface FooBar {
   array: string[] | null;
   childDomain: number | null;
+  date: string | null;
   defaultedNullablePosInt: Generated<number | null>;
   defaultedRequiredPosInt: Generated<number>;
   /**

--- a/src/generator/transformer/transform.test.ts
+++ b/src/generator/transformer/transform.test.ts
@@ -1,5 +1,6 @@
 import { deepStrictEqual } from 'assert';
 import { describe, it } from 'vitest';
+import { DateParser } from '../../introspector/dialects/postgres/date-parser';
 import { NumericParser } from '../../introspector/dialects/postgres/numeric-parser';
 import { EnumCollection } from '../../introspector/enum-collection';
 import { ColumnMetadata } from '../../introspector/metadata/column-metadata';
@@ -34,11 +35,13 @@ describe(transform.name, () => {
 
   const transformWithDefaults = ({
     camelCase,
+    dateParser,
     numericParser,
     runtimeEnums,
     tables,
   }: {
     camelCase?: boolean;
+    dateParser?: DateParser;
     numericParser?: NumericParser;
     runtimeEnums?: boolean;
     runtimeEnumsStyle?: RuntimeEnumsStyle;
@@ -46,7 +49,7 @@ describe(transform.name, () => {
   }) => {
     return transform({
       camelCase,
-      dialect: new PostgresDialect({ numericParser }),
+      dialect: new PostgresDialect({ dateParser, numericParser }),
       metadata: new DatabaseMetadata({ enums, tables }),
       overrides: {
         columns: {
@@ -254,6 +257,45 @@ describe(transform.name, () => {
           'DB',
           new ObjectExpressionNode([
             new PropertyNode('fooBar', new IdentifierNode('FooBar')),
+          ]),
+        ),
+      ),
+    ]);
+  });
+
+  it('should be able to transform using an alternative Postgres date parser', () => {
+    const nodes = transformWithDefaults({
+      dateParser: DateParser.STRING,
+      tables: [
+        new TableMetadata({
+          columns: [
+            new ColumnMetadata({
+              dataType: 'date',
+              name: 'date',
+            }),
+          ],
+          name: 'table',
+        }),
+      ],
+    });
+
+    deepStrictEqual(nodes, [
+      new ExportStatementNode(
+        new InterfaceDeclarationNode(
+          'Table',
+          new ObjectExpressionNode([
+            new PropertyNode(
+              'date',
+              new IdentifierNode('string'),
+            ),
+          ]),
+        ),
+      ),
+      new ExportStatementNode(
+        new InterfaceDeclarationNode(
+          'DB',
+          new ObjectExpressionNode([
+            new PropertyNode('table', new IdentifierNode('Table')),
           ]),
         ),
       ),

--- a/src/introspector/dialects/postgres/date-parser.ts
+++ b/src/introspector/dialects/postgres/date-parser.ts
@@ -1,0 +1,6 @@
+export const enum DateParser {
+  STRING = 'string',
+  TIMESTAMP = 'timestamp'
+}
+
+export const DEFAULT_DATE_PARSER = DateParser.TIMESTAMP;

--- a/src/introspector/dialects/postgres/postgres-dialect.ts
+++ b/src/introspector/dialects/postgres/postgres-dialect.ts
@@ -3,8 +3,10 @@ import type { CreateKyselyDialectOptions } from '../../dialect';
 import { IntrospectorDialect } from '../../dialect';
 import { DEFAULT_NUMERIC_PARSER, NumericParser } from './numeric-parser';
 import { PostgresIntrospector } from './postgres-introspector';
+import { DateParser, DEFAULT_DATE_PARSER } from './date-parser';
 
 type PostgresDialectOptions = {
+  dateParser?: DateParser;
   defaultSchemas?: string[];
   domains?: boolean;
   numericParser?: NumericParser;
@@ -24,6 +26,7 @@ export class PostgresIntrospectorDialect extends IntrospectorDialect {
       partitions: options?.partitions,
     });
     this.options = {
+      dateParser: options?.dateParser ?? DEFAULT_DATE_PARSER,
       defaultSchemas: options?.defaultSchemas,
       domains: options?.domains ?? true,
       numericParser: options?.numericParser ?? DEFAULT_NUMERIC_PARSER,
@@ -43,6 +46,10 @@ export class PostgresIntrospectorDialect extends IntrospectorDialect {
           ? value
           : number;
       });
+    }
+
+    if (this.options.dateParser === DateParser.STRING) {
+      pg.types.setTypeParser(1082, (date) => date);
     }
 
     return new KyselyPostgresDialect({

--- a/src/introspector/index.ts
+++ b/src/introspector/index.ts
@@ -7,6 +7,7 @@ export * from './dialects/mysql/mysql-db';
 export * from './dialects/mysql/mysql-dialect';
 export * from './dialects/mysql/mysql-introspector';
 export * from './dialects/mysql/mysql-parser';
+export * from './dialects/postgres/date-parser';
 export * from './dialects/postgres/numeric-parser';
 export * from './dialects/postgres/postgres-db';
 export * from './dialects/postgres/postgres-dialect';

--- a/src/introspector/introspector.fixtures.ts
+++ b/src/introspector/introspector.fixtures.ts
@@ -68,6 +68,7 @@ const up = async (db: Kysely<any>, dialect: IntrospectorDialect) => {
     } else if (dialect instanceof PostgresIntrospectorDialect) {
       builder = builder
         .addColumn('id', 'serial')
+        .addColumn('date', 'date')
         .addColumn('user_status', sql`status`)
         .addColumn('user_status_2', sql`test.status`)
         .addColumn('array', sql`text[]`)

--- a/src/introspector/introspector.test.ts
+++ b/src/introspector/introspector.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual } from 'assert';
 import { type Kysely } from 'kysely';
 import parsePostgresInterval from 'postgres-interval';
 import { describe, test } from 'vitest';
+import { DateParser } from './dialects/postgres/date-parser';
 import { NumericParser } from '../introspector/dialects/postgres/numeric-parser';
 import { migrate } from '../introspector/introspector.fixtures';
 import type { IntrospectorDialect } from './dialect';
@@ -32,10 +33,12 @@ const TESTS: Test[] = [
   {
     connectionString: 'postgres://user:password@localhost:5433/database',
     dialect: new PostgresIntrospectorDialect({
+      dateParser: DateParser.STRING,
       numericParser: NumericParser.NUMBER_OR_STRING,
     }),
     inputValues: {
       false: false,
+      date: '2024-10-14',
       id: 1,
       interval1: parsePostgresInterval('1 day'),
       interval2: '24 months',
@@ -46,6 +49,7 @@ const TESTS: Test[] = [
     },
     outputValues: {
       false: false,
+      date: '2024-10-14',
       id: 1,
       interval1: { days: 1 },
       interval2: { years: 2 },
@@ -181,6 +185,12 @@ describe(Introspector.name, () => {
                       hasDefaultValue: true,
                       isAutoIncrementing: true,
                       name: 'id',
+                    }),
+                    new ColumnMetadata({
+                      dataType: 'date',
+                      dataTypeSchema: 'pg_catalog',
+                      isNullable: true,
+                      name: 'date',
                     }),
                     new ColumnMetadata({
                       dataType: 'status',


### PR DESCRIPTION
Many people prefer to parse DATE columns as `strings` due to timezone issues with JS `Date`s. This adds a new flag, `--date-parser`, that allows the user to choose between using `Date` or `string` as the type for DATE columns.

I mostly just pattern matched against how `--numeric-parser` was implemented.

Closes #194 