### PR TITLE
fix: #105 Generated type for sqlite integer primary key

### DIFF
--- a/src/introspector/dialects/sqlite/sqlite-introspector.ts
+++ b/src/introspector/dialects/sqlite/sqlite-introspector.ts
@@ -1,12 +1,53 @@
+import { Kysely, sql, TableMetadata } from 'kysely';
 import { EnumCollection } from '../../enum-collection';
 import type { IntrospectOptions } from '../../introspector';
 import { Introspector } from '../../introspector';
 import { DatabaseMetadata } from '../../metadata/database-metadata';
 
+interface TableInfo {
+  cid: number;
+  name: string;
+  type: string;
+  notnull: 0 | 1;
+  pk: number;
+}
+
 export class SqliteIntrospector extends Introspector<any> {
   async introspect(options: IntrospectOptions<any>) {
-    const tables = await this.getTables(options);
+    const tables = await this.sqliteAutoincrement(
+      options.db,
+      await this.getTables(options),
+    );
     const enums = new EnumCollection();
     return new DatabaseMetadata({ enums, tables });
+  }
+
+  // https://www.sqlite.org/autoinc.html
+  protected sqliteAutoincrement(db: Kysely<any>, tables: TableMetadata[]) {
+    return Promise.all(
+      tables.map(async (t) => {
+        if (t.columns.some((t) => t.isAutoIncrementing)) {
+          return t;
+        }
+        const { rows } =
+          await sql<TableInfo>`PRAGMA table_info(${sql.id(t.name)})`.execute(
+            db,
+          );
+        const pkCol = rows.find(
+          (r) => r.type.toLowerCase() === 'integer' && r.pk > 0,
+        );
+        if (!pkCol) {
+          return t;
+        }
+        return {
+          ...t,
+          columns: t.columns.map((t) => {
+            return t.name === pkCol.name
+              ? { ...t, isAutoIncrementing: true }
+              : t;
+          }),
+        };
+      }),
+    );
   }
 }

--- a/src/introspector/dialects/sqlite/sqlite-introspector.ts
+++ b/src/introspector/dialects/sqlite/sqlite-introspector.ts
@@ -33,12 +33,13 @@ export class SqliteIntrospector extends Introspector<any> {
           await sql<TableInfo>`PRAGMA table_info(${sql.id(t.name)})`.execute(
             db,
           );
-        const pkCol = rows.find(
+        const pkCols = rows.filter(
           (r) => r.type.toLowerCase() === 'integer' && r.pk > 0,
         );
-        if (!pkCol) {
+        if (!pkCols[0] || pkCols.length > 1) {
           return t;
         }
+        const pkCol = pkCols[0];
         return {
           ...t,
           columns: t.columns.map((t) => {

--- a/src/introspector/introspector.fixtures.ts
+++ b/src/introspector/introspector.fixtures.ts
@@ -90,9 +90,7 @@ const up = async (db: Kysely<any>, dialect: IntrospectorDialect) => {
         .addColumn('numeric2', sql`numeric`);
     } else {
       builder = builder
-        .addColumn('id', 'integer', (col) =>
-          col.autoIncrement().notNull().primaryKey(),
-        )
+        .addColumn('id', 'integer', (col) => col.notNull().primaryKey())
         .addColumn('user_status', 'text');
     }
 


### PR DESCRIPTION
Fixes #105

SQLite does not require an explicit `AUTOINCREMENT` for the column to have a generated row id. In fact, the SQLite docs actually [discourage this](https://www.sqlite.org/autoinc.html), preferring a `INTEGER PRIMARY KEY`.

Kysely's default introspection does not take this into account when setting `isAutoIncrementing`. This PR gets the additional information out of `PRAGMA table_info` for any tables where we don't see an explicit incrementing key, but do see an `INTEGER PRIMARY KEY`