### PR TITLE
feat: return non-zero code when error occurs

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -299,12 +299,12 @@ export class Cli {
             throw error;
           } else {
             console.error(new Logger().serializeError(error.message));
-            process.exit(0);
           }
         } else {
           throw error;
         }
       }
+      process.exit(1);
     }
   }
 }


### PR DESCRIPTION
Fixes #213 - Return non-zero error code when verify fails.

# Verification

Unit tests continue to pass.

Tested locally against database with mismatching types:

Before:
<img width="980" alt="Screenshot 2025-02-17 at 12 04 28 PM" src="https://github.com/user-attachments/assets/f4209f22-1e06-44ca-bf84-3db67d259487" />

After:
<img width="987" alt="Screenshot 2025-02-17 at 12 05 06 PM" src="https://github.com/user-attachments/assets/15736f9c-c4f6-4cbb-8adb-c6ceb53a497c" />
