### PR TITLE
fix: update timestamp definition if date parser is string

### DIFF
--- a/src/generator/dialects/postgres/postgres-adapter.ts
+++ b/src/generator/dialects/postgres/postgres-adapter.ts
@@ -141,6 +141,12 @@ export class PostgresAdapter extends Adapter {
 
     if (options?.dateParser === 'string') {
       this.scalars.date = new IdentifierNode('string');
+
+      this.definitions.Timestamp = new ColumnTypeNode(
+        new IdentifierNode('string'),
+        new IdentifierNode('string'),
+        new IdentifierNode('string')
+      );
     } else {
       this.scalars.date = new IdentifierNode('Timestamp');
     }


### PR DESCRIPTION
## Bug: `--date-parser string` doesn't properly update Timestamp type definition

When using `--date-parser string`, only the `date` scalar type is updated to use string, while the `Timestamp` type definition still includes `Date`. This results in inconsistent type generation where timestamp columns still show `Date | string` instead of just `string`.

### Current Behavior
With `--date-parser string`, the generated types show:
```typescript
export type Timestamp = ColumnType<string, Date | string, Date | string>;
```

### Expected Behavior
With `--date-parser string`, the generated types should show:
```typescript
export type Timestamp = ColumnType<string, string, string>;
```

### Proposed Fix
In `src/generator/dialects/postgres/postgres-adapter.ts`, update the constructor to handle both `date` scalar and `Timestamp` definition:

```typescript
constructor(options?: PostgresAdapterOptions) {
  super();
  if (options?.dateParser === DateParser.STRING) {
    // Update date scalar
    this.scalars.date = new IdentifierNode('string');
    
    // Update Timestamp definition
    this.definitions.Timestamp = new ColumnTypeNode(
      new IdentifierNode('string'),
      new IdentifierNode('string'),
      new IdentifierNode('string')
    );
  } else {
    this.scalars.date = new IdentifierNode('Timestamp');
  }
  // ... rest of constructor
}
```

### Additional Context
- The current implementation only updates the `date` scalar type but not the `Timestamp` definition
- This causes inconsistency in type generation when using `--date-parser string`
- The fix ensures both date-related types are properly updated to use string-only types