### PR TITLE
Add missing cli arg "config-file" to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ export interface User {
 }
 ```
 
+#### --config-file <!-- omit from toc -->
+
+Specify the path to the configuration file to use.
+
 #### --date-parser <!-- omit from toc -->
 
 Specify which parser to use for PostgreSQL date values. (values: `string`/`timestamp`, default: `timestamp`)


### PR DESCRIPTION
I had to find this out by prompting the cli or reading the code, but the documentation is missing this argument, which is important if you want to use custom serializers and dialects (https://github.com/RobinBlomberg/kysely-codegen/releases/tag/0.18.0)
