### PR TITLE
feat: Add support for foreign tables

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -52,6 +52,7 @@ export class Cli {
     const dialect = getDialect(dialectName, {
       dateParser: options.dateParser,
       domains: options.domains,
+      foreignTables: options.foreignTables,
       numericParser: options.numericParser,
       partitions: options.partitions,
     });
@@ -67,6 +68,7 @@ export class Cli {
       defaultSchemas: options.defaultSchemas,
       dialect,
       excludePattern: options.excludePattern,
+      foreignTables: options.foreignTables,
       includePattern: options.includePattern,
       logger,
       outFile: options.outFile,
@@ -234,6 +236,7 @@ export class Cli {
       domains: this.#parseBoolean(argv.domains),
       envFile: this.#parseString(argv['env-file']),
       excludePattern: this.#parseString(argv['exclude-pattern']),
+      foreignTables: this.#parseBoolean(argv['foreign-tables']),
       includePattern: this.#parseString(argv['include-pattern']),
       logLevel,
       numericParser: this.#parseNumericParser(argv['numeric-parser']),

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -30,6 +30,7 @@ export type Config = {
   domains?: boolean;
   envFile?: string;
   excludePattern?: string | null;
+  foreignTables?: boolean;
   includePattern?: string | null;
   logger?: Logger;
   logLevel?: LogLevel;
@@ -88,6 +89,7 @@ export const configSchema = z.object({
   domains: z.boolean().optional(),
   envFile: z.string().optional(),
   excludePattern: z.string().nullable().optional(),
+  foreignTables: z.boolean().optional(),
   includePattern: z.string().nullable().optional(),
   logger: z.instanceof(Logger).optional(),
   logLevel: z.enum(LOG_LEVELS).optional(),

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -50,6 +50,10 @@ export const FLAGS = [
     longName: 'exclude-pattern',
   },
   {
+    description: 'Include foreign tables (FDW) in the generated code.',
+    longName: 'foreign-tables',
+  },
+  {
     description: 'Print this message.',
     longName: 'help',
     shortName: 'h',

--- a/src/generator/dialects/postgres/postgres-dialect.ts
+++ b/src/generator/dialects/postgres/postgres-dialect.ts
@@ -8,6 +8,7 @@ export type PostgresDialectOptions = {
   dateParser?: DateParser;
   defaultSchemas?: string[];
   domains?: boolean;
+  foreignTables?: boolean;
   numericParser?: NumericParser;
   partitions?: boolean;
 };
@@ -23,6 +24,7 @@ export class PostgresDialect
       dateParser: options?.dateParser,
       defaultSchemas: options?.defaultSchemas,
       domains: options?.domains,
+      foreignTables: options?.foreignTables,
       numericParser: options?.numericParser,
       partitions: options?.partitions,
     });

--- a/src/generator/generator/generate.ts
+++ b/src/generator/generator/generate.ts
@@ -18,6 +18,7 @@ export type GenerateOptions = {
   defaultSchemas?: string[];
   dialect: GeneratorDialect;
   excludePattern?: string | null;
+  foreignTables?: boolean;
   includePattern?: string | null;
   logger?: Logger;
   outFile?: string | null;
@@ -36,6 +37,7 @@ export type SerializeFromMetadataOptions = Omit<
   GenerateOptions,
   | 'db'
   | 'excludePattern'
+  | 'foreignTables'
   | 'includePattern'
   | 'outFile'
   | 'partitions'
@@ -54,6 +56,7 @@ export const generate = async (options: GenerateOptions) => {
   const metadata = await options.dialect.introspector.introspect({
     db: options.db,
     excludePattern: options.excludePattern,
+    foreignTables: options.foreignTables,
     includePattern: options.includePattern,
     partitions: options.partitions,
   });

--- a/src/introspector/dialects/postgres/postgres-dialect.ts
+++ b/src/introspector/dialects/postgres/postgres-dialect.ts
@@ -11,6 +11,7 @@ type PostgresDialectOptions = {
   dateParser?: DateParser;
   defaultSchemas?: string[];
   domains?: boolean;
+  foreignTables?: boolean;
   numericParser?: NumericParser;
   partitions?: boolean;
 };
@@ -25,12 +26,14 @@ export class PostgresIntrospectorDialect extends IntrospectorDialect {
     this.introspector = new PostgresIntrospector({
       defaultSchemas: options?.defaultSchemas,
       domains: options?.domains,
+      foreignTables: options?.foreignTables,
       partitions: options?.partitions,
     });
     this.options = {
       dateParser: options?.dateParser ?? DEFAULT_DATE_PARSER,
       defaultSchemas: options?.defaultSchemas,
       domains: options?.domains ?? true,
+      foreignTables: options?.foreignTables,
       numericParser: options?.numericParser ?? DEFAULT_NUMERIC_PARSER,
     };
   }

--- a/src/introspector/introspector.ts
+++ b/src/introspector/introspector.ts
@@ -11,6 +11,7 @@ type ConnectOptions = {
 export type IntrospectOptions<DB> = {
   db: Kysely<DB>;
   excludePattern?: string | null;
+  foreignTables?: boolean;
   includePattern?: string | null;
   partitions?: boolean;
 };
@@ -53,7 +54,10 @@ export abstract class Introspector<DB> {
   }
 
   protected async getTables(options: IntrospectOptions<DB>) {
-    let tables = await options.db.introspection.getTables();
+    let tables = await options.db.introspection.getTables({
+      withForeignTables: options.foreignTables ?? false,
+      withInternalKyselyTables: false,
+    });
 
     if (options.includePattern) {
       const tableMatcher = new TableMatcher(options.includePattern);

--- a/src/introspector/metadata/table-metadata.ts
+++ b/src/introspector/metadata/table-metadata.ts
@@ -3,6 +3,7 @@ import { ColumnMetadata } from './column-metadata';
 
 export type TableMetadataOptions = {
   columns: ColumnMetadataOptions[];
+  isForeignTable?: boolean;
   isPartition?: boolean;
   isView?: boolean;
   name: string;
@@ -11,6 +12,7 @@ export type TableMetadataOptions = {
 
 export class TableMetadata {
   columns: ColumnMetadata[];
+  isForeignTable: boolean;
   isPartition: boolean;
   isView: boolean;
   name: string;
@@ -18,6 +20,7 @@ export class TableMetadata {
 
   constructor(options: TableMetadataOptions) {
     this.columns = options.columns.map((column) => new ColumnMetadata(column));
+    this.isForeignTable = !!options.isForeignTable;
     this.isPartition = !!options.isPartition;
     this.isView = !!options.isView;
     this.name = options.name;


### PR DESCRIPTION
Dependant on https://github.com/kysely-org/kysely/pull/1494

Adds a option `--foreign-tables` which will include postgres foreign tables in the generated types