### PR TITLE
README: Pin @tediousjs/connection-string to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install kysely mysql2
 npm install kysely better-sqlite3
 
 # MSSQL
-npm install kysely tedious tarn @tediousjs/connection-string
+npm install kysely tedious tarn @tediousjs/connection-string@0.5.0
 
 # LibSQL
 npm install @libsql/kysely-libsql


### PR DESCRIPTION
as 1.0.0 was released with breaking changes.

As is, following the README brings peer dep errors resulting in:

```
├── @tediousjs/connection-string@1.0.0
├─┬ kysely-codegen@0.18.5
│ └── @tediousjs/connection-string@1.0.0 deduped invalid: ">=0.5.0 <0.6.0" from node_modules/kysely-codegen
└─┬ mssql@11.0.1
  └── @tediousjs/connection-string@0.5.0
```