### PR TITLE
fix(GH-287): Fix for generic type imports

### DIFF
--- a/src/generator/parser/type-expression-parser.test.ts
+++ b/src/generator/parser/type-expression-parser.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from 'vitest';
+import { TypeExpressionParser } from './type-expression-parser';
+import { GenericExpressionNode } from '../ast/generic-expression-node';
+import { IdentifierNode } from '../ast/identifier-node';
+import { UnionExpressionNode } from '../ast/union-expression-node';
+import { LiteralNode } from '../ast/literal-node';
+import { RawExpressionNode } from '../ast/raw-expression-node';
+
+describe('TypeExpressionParser', () => {
+  const parser = new TypeExpressionParser();
+
+  describe('parse', () => {
+    test('should parse simple identifiers', () => {
+      const result = parser.parse('CustomType');
+      expect(result).toBeInstanceOf(IdentifierNode);
+      expect((result as IdentifierNode).name).toBe('CustomType');
+    });
+
+    test('should parse identifiers with underscores', () => {
+      const result = parser.parse('MY_CUSTOM_TYPE');
+      expect(result).toBeInstanceOf(IdentifierNode);
+      expect((result as IdentifierNode).name).toBe('MY_CUSTOM_TYPE');
+    });
+
+    test('should parse generic types with single parameter', () => {
+      const result = parser.parse('JSONColumnType<CustomType>');
+      expect(result).toBeInstanceOf(GenericExpressionNode);
+      const generic = result as GenericExpressionNode;
+      expect(generic.name).toBe('JSONColumnType');
+      expect(generic.args).toHaveLength(1);
+      expect(generic.args[0]).toBeInstanceOf(IdentifierNode);
+      expect((generic.args[0] as IdentifierNode).name).toBe('CustomType');
+    });
+
+    test('should parse generic types with multiple parameters', () => {
+      const result = parser.parse('Map<string, CustomType>');
+      expect(result).toBeInstanceOf(GenericExpressionNode);
+      const generic = result as GenericExpressionNode;
+      expect(generic.name).toBe('Map');
+      expect(generic.args).toHaveLength(2);
+      expect((generic.args[0] as IdentifierNode).name).toBe('string');
+      expect((generic.args[1] as IdentifierNode).name).toBe('CustomType');
+    });
+
+    test('should parse nested generic types', () => {
+      const result = parser.parse('Map<string, Array<CustomType>>');
+      expect(result).toBeInstanceOf(GenericExpressionNode);
+      const map = result as GenericExpressionNode;
+      expect(map.name).toBe('Map');
+      expect(map.args).toHaveLength(2);
+      expect((map.args[0] as IdentifierNode).name).toBe('string');
+
+      const array = map.args[1] as GenericExpressionNode;
+      expect(array).toBeInstanceOf(GenericExpressionNode);
+      expect(array.name).toBe('Array');
+      expect(array.args).toHaveLength(1);
+      expect((array.args[0] as IdentifierNode).name).toBe('CustomType');
+    });
+
+    test('should parse union types', () => {
+      const result = parser.parse('TypeA | TypeB | TypeC');
+      expect(result).toBeInstanceOf(UnionExpressionNode);
+      const union = result as UnionExpressionNode;
+      expect(union.args).toHaveLength(3);
+      expect((union.args[0] as IdentifierNode).name).toBe('TypeA');
+      expect((union.args[1] as IdentifierNode).name).toBe('TypeB');
+      expect((union.args[2] as IdentifierNode).name).toBe('TypeC');
+    });
+
+    test('should parse string literal types', () => {
+      const result = parser.parse('"active"');
+      expect(result).toBeInstanceOf(LiteralNode);
+      expect((result as LiteralNode).value).toBe('active');
+    });
+
+    test('should parse string literal unions', () => {
+      const result = parser.parse('"active" | "inactive" | "pending"');
+      expect(result).toBeInstanceOf(UnionExpressionNode);
+      const union = result as UnionExpressionNode;
+      expect(union.args).toHaveLength(3);
+      expect((union.args[0] as LiteralNode).value).toBe('active');
+      expect((union.args[1] as LiteralNode).value).toBe('inactive');
+      expect((union.args[2] as LiteralNode).value).toBe('pending');
+    });
+
+    test('should parse number literal types', () => {
+      const result = parser.parse('42');
+      expect(result).toBeInstanceOf(LiteralNode);
+      expect((result as LiteralNode).value).toBe(42);
+    });
+
+    test('should parse boolean literal types', () => {
+      const trueResult = parser.parse('true');
+      expect(trueResult).toBeInstanceOf(IdentifierNode);
+      expect((trueResult as IdentifierNode).name).toBe('true');
+
+      const falseResult = parser.parse('false');
+      expect(falseResult).toBeInstanceOf(IdentifierNode);
+      expect((falseResult as IdentifierNode).name).toBe('false');
+    });
+
+    test('should parse mixed literal unions', () => {
+      const result = parser.parse('"auto" | 100 | true | null');
+      expect(result).toBeInstanceOf(UnionExpressionNode);
+      const union = result as UnionExpressionNode;
+      expect(union.args).toHaveLength(4);
+      expect((union.args[0] as LiteralNode).value).toBe('auto');
+      expect((union.args[1] as LiteralNode).value).toBe(100);
+      expect((union.args[2] as IdentifierNode).name).toBe('true');
+      expect((union.args[3] as IdentifierNode).name).toBe('null');
+    });
+
+    test('should parse primitive types', () => {
+      expect((parser.parse('string') as IdentifierNode).name).toBe('string');
+      expect((parser.parse('number') as IdentifierNode).name).toBe('number');
+      expect((parser.parse('boolean') as IdentifierNode).name).toBe('boolean');
+      expect((parser.parse('null') as IdentifierNode).name).toBe('null');
+      expect((parser.parse('undefined') as IdentifierNode).name).toBe(
+        'undefined',
+      );
+      expect((parser.parse('never') as IdentifierNode).name).toBe('never');
+      expect((parser.parse('any') as IdentifierNode).name).toBe('any');
+      expect((parser.parse('unknown') as IdentifierNode).name).toBe('unknown');
+    });
+
+    test('should preserve array syntax as RawExpressionNode', () => {
+      const result = parser.parse('CustomType[]');
+      expect(result).toBeInstanceOf(RawExpressionNode);
+      expect((result as RawExpressionNode).expression).toBe('CustomType[]');
+    });
+
+    test('should preserve multi-dimensional array syntax', () => {
+      const result = parser.parse('CustomType[][]');
+      expect(result).toBeInstanceOf(RawExpressionNode);
+      expect((result as RawExpressionNode).expression).toBe('CustomType[][]');
+    });
+
+    test('should preserve intersection types as RawExpressionNode', () => {
+      const result = parser.parse('TypeA & TypeB & TypeC');
+      expect(result).toBeInstanceOf(RawExpressionNode);
+      expect((result as RawExpressionNode).expression).toBe(
+        'TypeA & TypeB & TypeC',
+      );
+    });
+
+    test('should preserve object literal types as RawExpressionNode', () => {
+      const result = parser.parse('{ tags: string[] }');
+      expect(result).toBeInstanceOf(RawExpressionNode);
+      expect((result as RawExpressionNode).expression).toBe(
+        '{ tags: string[] }',
+      );
+    });
+
+    test('should handle complex mixed expressions', () => {
+      const result = parser.parse(
+        'JSONColumnType<Partial<UserData> & { tags: string[] }>',
+      );
+      expect(result).toBeInstanceOf(GenericExpressionNode);
+      const generic = result as GenericExpressionNode;
+      expect(generic.name).toBe('JSONColumnType');
+      expect(generic.args).toHaveLength(1);
+      // The intersection type inside should be preserved as RawExpression
+      expect(generic.args[0]).toBeInstanceOf(RawExpressionNode);
+      expect((generic.args[0] as RawExpressionNode).expression).toBe(
+        'Partial<UserData> & { tags: string[] }',
+      );
+    });
+
+    test('should handle ColumnType with three parameters', () => {
+      const result = parser.parse('ColumnType<string, string, never>');
+      expect(result).toBeInstanceOf(GenericExpressionNode);
+      const generic = result as GenericExpressionNode;
+      expect(generic.name).toBe('ColumnType');
+      expect(generic.args).toHaveLength(3);
+      expect((generic.args[0] as IdentifierNode).name).toBe('string');
+      expect((generic.args[1] as IdentifierNode).name).toBe('string');
+      expect((generic.args[2] as IdentifierNode).name).toBe('never');
+    });
+
+    test('should handle empty string', () => {
+      const result = parser.parse('');
+      expect(result).toBeInstanceOf(RawExpressionNode);
+      expect((result as RawExpressionNode).expression).toBe('');
+    });
+  });
+
+  describe('extractTypeIdentifiers', () => {
+    test('should extract identifiers from simple types', () => {
+      const identifiers = parser.extractTypeIdentifiers('CustomType');
+      expect(identifiers).toEqual(['CustomType']);
+    });
+
+    test('should extract identifiers from generic types', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'JSONColumnType<CustomType>',
+      );
+      expect(identifiers).toContain('JSONColumnType');
+      expect(identifiers).toContain('CustomType');
+      expect(identifiers).toHaveLength(2);
+    });
+
+    test('should extract identifiers from nested generics', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'Map<string, Array<Partial<User>>>',
+      );
+      expect(identifiers).toContain('Map');
+      expect(identifiers).toContain('Array');
+      expect(identifiers).toContain('Partial');
+      expect(identifiers).toContain('User');
+      expect(identifiers).not.toContain('string'); // Built-in types are included
+    });
+
+    test('should extract identifiers from union types', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'TypeA | TypeB | TypeC | null',
+      );
+      expect(identifiers).toContain('TypeA');
+      expect(identifiers).toContain('TypeB');
+      expect(identifiers).toContain('TypeC');
+      expect(identifiers).not.toContain('null'); // null is not collected as it's a keyword
+    });
+
+    test('should extract identifiers from intersection types', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'BaseModel & Timestamped & Authored',
+      );
+      expect(identifiers).toContain('BaseModel');
+      expect(identifiers).toContain('Timestamped');
+      expect(identifiers).toContain('Authored');
+    });
+
+    test('should extract identifiers from array types', () => {
+      const identifiers = parser.extractTypeIdentifiers('CustomType[]');
+      expect(identifiers).toEqual(['CustomType']);
+    });
+
+    test('should extract identifiers from multi-dimensional arrays', () => {
+      const identifiers = parser.extractTypeIdentifiers('NestedType[][]');
+      expect(identifiers).toEqual(['NestedType']);
+    });
+
+    test('should handle complex mixed types', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'JSONColumnType<Partial<UserData> & { tags: string[] }>',
+      );
+      expect(identifiers).toContain('JSONColumnType');
+      expect(identifiers).toContain('Partial');
+      expect(identifiers).toContain('UserData');
+    });
+
+    test('should not extract literal types', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        '"active" | "inactive" | 123 | true',
+      );
+      expect(identifiers).toEqual([]);
+    });
+
+    test('should handle types with underscores', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'MY_CUSTOM_TYPE | Type_With_Underscores',
+      );
+      expect(identifiers).toContain('MY_CUSTOM_TYPE');
+      expect(identifiers).toContain('Type_With_Underscores');
+    });
+
+    test('should handle ColumnType with parameters', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'ColumnType<Permission[], string, Permission[] | null>',
+      );
+      expect(identifiers).toContain('ColumnType');
+      expect(identifiers).toContain('Permission');
+      expect(identifiers).toHaveLength(2); // ColumnType and Permission (deduplicated)
+    });
+
+    test('should handle empty string', () => {
+      const identifiers = parser.extractTypeIdentifiers('');
+      expect(identifiers).toEqual([]);
+    });
+
+    test('should handle conditional types', () => {
+      const identifiers = parser.extractTypeIdentifiers(
+        'T extends User ? Admin : Guest',
+      );
+      expect(identifiers).toContain('T');
+      expect(identifiers).toContain('User');
+      expect(identifiers).toContain('Admin');
+      expect(identifiers).toContain('Guest');
+    });
+
+    test('should handle indexed access types', () => {
+      const identifiers = parser.extractTypeIdentifiers('User["id"]');
+      expect(identifiers).toContain('User');
+    });
+
+    test('should handle tuple types', () => {
+      const identifiers = parser.extractTypeIdentifiers('[User, Admin, Guest]');
+      expect(identifiers).toContain('User');
+      expect(identifiers).toContain('Admin');
+      expect(identifiers).toContain('Guest');
+    });
+  });
+});

--- a/src/generator/parser/type-expression-parser.ts
+++ b/src/generator/parser/type-expression-parser.ts
@@ -1,0 +1,209 @@
+import * as ts from 'typescript';
+import { GenericExpressionNode } from '../ast/generic-expression-node';
+import { IdentifierNode } from '../ast/identifier-node';
+import { UnionExpressionNode } from '../ast/union-expression-node';
+import { LiteralNode } from '../ast/literal-node';
+import { RawExpressionNode } from '../ast/raw-expression-node';
+import type { ExpressionNode } from '../ast/expression-node';
+
+/**
+ * Parses a TypeScript type expression string into kysely-codegen AST nodes.
+ * This properly handles all TypeScript syntax including generics, unions,
+ * intersections, and complex nested types.
+ */
+export class TypeExpressionParser {
+  private sourceFile!: ts.SourceFile;
+
+  /**
+   * Parse a TypeScript type expression string into AST nodes
+   * @param typeExpression - The type expression string (e.g., "JSONColumnType<CustomType>")
+   * @returns The parsed AST node, or RawExpressionNode if parsing fails
+   */
+  parse(typeExpression: string): ExpressionNode {
+    // Handle empty string edge case
+    if (!typeExpression.trim()) {
+      return new RawExpressionNode(typeExpression);
+    }
+
+    try {
+      // Wrap the type in a type alias to make it a valid TypeScript statement
+      const sourceText = `type __T = ${typeExpression};`;
+
+      // Create a TypeScript source file
+      this.sourceFile = ts.createSourceFile(
+        'temp.ts',
+        sourceText,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+      );
+
+      // Find the type alias declaration
+      const typeAlias = this.sourceFile.statements.find((stmt) =>
+        ts.isTypeAliasDeclaration(stmt),
+      );
+
+      if (!typeAlias) {
+        return new RawExpressionNode(typeExpression);
+      }
+
+      // Convert the TypeScript AST to kysely-codegen AST
+      return this.convertTypeNode(typeAlias.type);
+    } catch (error) {
+      // If parsing fails for any reason, fall back to RawExpressionNode
+      console.warn(`Failed to parse type expression: ${typeExpression}`, error);
+      return new RawExpressionNode(typeExpression);
+    }
+  }
+
+  /**
+   * Extract all type identifiers from a type expression
+   * This is used for import collection
+   */
+  extractTypeIdentifiers(typeExpression: string): string[] {
+    // Handle empty string edge case
+    if (!typeExpression.trim()) {
+      return [];
+    }
+
+    try {
+      const sourceText = `type __T = ${typeExpression};`;
+      this.sourceFile = ts.createSourceFile(
+        'temp.ts',
+        sourceText,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+      );
+
+      const typeAlias = this.sourceFile.statements.find((stmt) =>
+        ts.isTypeAliasDeclaration(stmt),
+      );
+
+      if (!typeAlias) {
+        return [];
+      }
+
+      const identifiers = new Set<string>();
+      this.collectTypeReferences(typeAlias.type, identifiers);
+      return Array.from(identifiers);
+    } catch {
+      return [];
+    }
+  }
+
+  private collectTypeReferences(
+    node: ts.TypeNode,
+    identifiers: Set<string>,
+  ): void {
+    if (ts.isTypeReferenceNode(node)) {
+      const typeName = node.typeName.getText(this.sourceFile);
+      identifiers.add(typeName);
+
+      // Also collect type arguments
+      if (node.typeArguments) {
+        for (const arg of node.typeArguments) {
+          this.collectTypeReferences(arg, identifiers);
+        }
+      }
+    } else if (ts.isUnionTypeNode(node)) {
+      for (const type of node.types) {
+        this.collectTypeReferences(type, identifiers);
+      }
+    } else if (ts.isIntersectionTypeNode(node)) {
+      for (const type of node.types) {
+        this.collectTypeReferences(type, identifiers);
+      }
+    } else if (ts.isArrayTypeNode(node)) {
+      this.collectTypeReferences(node.elementType, identifiers);
+    } else if (ts.isTupleTypeNode(node)) {
+      for (const element of node.elements) {
+        if (ts.isNamedTupleMember(element)) {
+          this.collectTypeReferences(element.type, identifiers);
+        } else {
+          this.collectTypeReferences(element, identifiers);
+        }
+      }
+    } else if (ts.isConditionalTypeNode(node)) {
+      this.collectTypeReferences(node.checkType, identifiers);
+      this.collectTypeReferences(node.extendsType, identifiers);
+      this.collectTypeReferences(node.trueType, identifiers);
+      this.collectTypeReferences(node.falseType, identifiers);
+    } else if (ts.isMappedTypeNode(node)) {
+      if (node.type) {
+        this.collectTypeReferences(node.type, identifiers);
+      }
+    } else if (ts.isIndexedAccessTypeNode(node)) {
+      this.collectTypeReferences(node.objectType, identifiers);
+      this.collectTypeReferences(node.indexType, identifiers);
+    } else if (ts.isParenthesizedTypeNode(node)) {
+      this.collectTypeReferences(node.type, identifiers);
+    }
+    // Note: We don't collect from literal types, keyword types, etc.
+  }
+
+  private convertTypeNode(node: ts.TypeNode): ExpressionNode {
+    // For complex types (arrays, intersections, object types), preserve the original syntax
+    // by using RawExpressionNode. This maintains output fidelity.
+    if (
+      ts.isArrayTypeNode(node) ||
+      ts.isIntersectionTypeNode(node) ||
+      ts.isTypeLiteralNode(node)
+    ) {
+      const typeText = node.getText(this.sourceFile);
+      return new RawExpressionNode(typeText);
+    }
+
+    if (ts.isTypeReferenceNode(node)) {
+      const typeName = node.typeName.getText(this.sourceFile);
+
+      if (node.typeArguments && node.typeArguments.length > 0) {
+        // Generic type like JSONColumnType<CustomType>
+        const args = node.typeArguments.map((arg) => this.convertTypeNode(arg));
+        return new GenericExpressionNode(typeName, args);
+      }
+      // Simple identifier
+      return new IdentifierNode(typeName);
+    } else if (ts.isUnionTypeNode(node)) {
+      // Union type like A | B | C
+      const types = node.types.map((type) => this.convertTypeNode(type));
+      return types.length === 1 ? types[0]! : new UnionExpressionNode(types);
+    } else if (ts.isLiteralTypeNode(node)) {
+      // String literal type like "active" | "inactive"
+      if (ts.isStringLiteral(node.literal)) {
+        return new LiteralNode(node.literal.text);
+      } else if (node.literal.kind === ts.SyntaxKind.NullKeyword) {
+        return new IdentifierNode('null');
+      } else if (node.literal.kind === ts.SyntaxKind.TrueKeyword) {
+        return new IdentifierNode('true');
+      } else if (node.literal.kind === ts.SyntaxKind.FalseKeyword) {
+        return new IdentifierNode('false');
+      } else if (ts.isNumericLiteral(node.literal)) {
+        return new LiteralNode(Number(node.literal.text));
+      }
+    } else if (node.kind === ts.SyntaxKind.StringKeyword) {
+      return new IdentifierNode('string');
+    } else if (node.kind === ts.SyntaxKind.NumberKeyword) {
+      return new IdentifierNode('number');
+    } else if (node.kind === ts.SyntaxKind.BooleanKeyword) {
+      return new IdentifierNode('boolean');
+    } else if (node.kind === ts.SyntaxKind.NullKeyword) {
+      return new IdentifierNode('null');
+    } else if (node.kind === ts.SyntaxKind.UndefinedKeyword) {
+      return new IdentifierNode('undefined');
+    } else if (node.kind === ts.SyntaxKind.NeverKeyword) {
+      return new IdentifierNode('never');
+    } else if (node.kind === ts.SyntaxKind.AnyKeyword) {
+      return new IdentifierNode('any');
+    } else if (node.kind === ts.SyntaxKind.UnknownKeyword) {
+      return new IdentifierNode('unknown');
+    }
+
+    // For any other complex types, fall back to raw expression
+    const typeText = node.getText(this.sourceFile);
+    return new RawExpressionNode(typeText);
+  }
+}
+
+// Singleton instance for convenience
+export const typeExpressionParser = new TypeExpressionParser();

--- a/src/generator/transformer/symbol-collection.ts
+++ b/src/generator/transformer/symbol-collection.ts
@@ -78,11 +78,18 @@ export class SymbolCollection {
     }
 
     const symbolNames = new Set(Object.values(this.symbolNames));
-    const caseConverter =
-      this.identifierStyle === 'screaming-snake-case'
-        ? toScreamingSnakeCase
-        : toKyselyPascalCase;
-    symbolName = caseConverter(id.replaceAll(/[^\w$]/g, '_'));
+
+    // For ModuleReference symbols (imports), preserve the original name
+    // to maintain exact import names like MY_CUSTOM_TYPE
+    if (symbol.type === 'ModuleReference') {
+      symbolName = id;
+    } else {
+      const caseConverter =
+        this.identifierStyle === 'screaming-snake-case'
+          ? toScreamingSnakeCase
+          : toKyselyPascalCase;
+      symbolName = caseConverter(id.replaceAll(/[^\w$]/g, '_'));
+    }
 
     if (symbolNames.has(symbolName)) {
       let suffix = 2;


### PR DESCRIPTION
## Background Context

A previous PR (#274) added support for custom types. This means you could have a kysely config like this:

```ts
{
  customImports: {
    Instant: 'temporal-polyfill'
  },
  overrides: {
    columns: {
      'person.born_at': 'Instant'
    }
  }
}
```

## Problem

The problem was when you attempted to use generics in your column overrides:

```ts
{
  customImports: {
    Instant: 'temporal-polyfill'
  },
  overrides: {
    columns: {
      // 🐣 The 3rd param is `never`, since a person's birth time is immutable.
      'person.born_at': 'ColumnType<Instant, Instant, never>'
    }
  }
}
```

A bug in our parsing logic would cause the generic type parameter (in this case, `Instant`) not be imported in the resulting auto-generated code.

```ts
// Generated output (before fix)
import type { JSONColumnType } from "kysely";
// ❌ Missing: import type { Instant } from "temporal-polyfill";
```

## Solution

Resolves #287.

Replaced regex-based type extraction with a proper TypeScript AST parser using the TypeScript compiler API.

### Why AST over regex:
- ✅ Correctness: Handles all valid TypeScript syntax (nested generics, unions, intersections, etc.)
- ✅ Maintainability: Leverages TypeScript's own parser instead of maintaining complex regex patterns
- ✅ Robustness: Gracefully handles edge cases like `Map<string, Array<Partial<User>>>`
- ✅ Future-proof: Automatically supports new TypeScript syntax as the compiler evolves

### Supported Type Expressions

All of the following TypeScript type expressions are now correctly parsed and have their imports generated:

#### ✅ Generic Types

- `JSONColumnType<CustomType>` - Single type parameter
- `Map<string, CustomType>` - Multiple type parameters
- `ColumnType<string, string, never>` - Kysely column types

#### ✅ Nested Generics

- `Map<string, Array<Partial<User>>>` - Deeply nested
- `CustomMap<string, User[]>` - Mixed syntax
- `JSONColumnType<Partial<UserData> & { tags: string[] }>` - With inline object types

#### ✅ Union Types

- `TypeA | TypeB | TypeC` - Multiple unions
- `"active" | "inactive" | "pending"` - String literal unions
- `1 | 2 | 3` - Numeric literal unions
- `true | false` - Boolean literal unions
- `"auto" | 100 | true | null` - Mixed literal unions

#### ✅ Intersection Types

- `BaseModel & Timestamped & Authored` - Multiple intersections
- `Partial<UserData> & { tags: string[] }` - With inline types

#### ✅ Array Types

- `CustomType[]` - Array suffix notation (preserved as-is)
- `Array<CustomType>` - Generic array notation
- `NestedType[][]` - Multi-dimensional arrays

#### ✅ Built-in Type References

- `string`, `number`, `boolean` - Primitives
- `null`, `undefined`, `never`, `any`, `unknown` - Special types
- `Array`, `Map`, `Set` - Can be imported when in customImports

#### ✅ Special Cases

- `MY_CUSTOM_TYPE` - Types with underscores (preserved exactly)
- `Type_With_Underscores` - Mixed case with underscores
- `Generated<number>` - Kysely's Generated type

### Intentionally Unsupported (Fall Back to `RawExpressionNode`)

These complex TypeScript features still work but are preserved as raw strings for output fidelity:

#### ⚠️ Not Parsed into AST Nodes

- Conditional Types: `T extends U ? X : Y` - Too complex for current AST structure
- Template Literal Types: `` `prefix_${T}` `` - Would require new AST node types
- Mapped Types: `{ [K in keyof T]: T[K] }` - Would require object type support
- Index Access Types: `T['property']` - Would need property access nodes
- Tuple Types: `[string, number, boolean]` - Would need tuple-specific nodes
- Function Types: `(arg: T) => U` - Not typically used in column overrides
- Infer Types: `T extends Array<infer U> ? U : never` - Too complex

> [!NOTE]
>
> These types are still handled correctly for import extraction - we parse them with TypeScript's compiler to find all type references, but we don't convert them to kysely-codegen AST nodes. They remain as `RawExpressionNode` with the original string, ensuring the generated output is exactly what the user specified.

### Additional improvements

  - Types with underscores (`MY_CUSTOM_TYPE`) now preserve their exact names
  - Built-in types (`Array`, `Map`) can be imported when specified in customImports
  - Comprehensive test coverage for all TypeScript type expressions
  - Preserves original syntax fidelity (e.g., `CustomType[]` stays as-is, not converted to `Array<CustomType>`)