### PR TITLE
Support subpath imports for named imports

### DIFF
--- a/src/generator/transformer/transformer.ts
+++ b/src/generator/transformer/transformer.ts
@@ -176,7 +176,8 @@ const createContext = (options: TransformOptions): TransformContext => {
   // Convert custom imports to `ModuleReferenceNode` instances:
   for (const [name, moduleSpec] of Object.entries(customImports)) {
     // Parse the `#` syntax for named imports:
-    const hashIndex = moduleSpec.indexOf('#');
+    const isSubpathImport = moduleSpec[0] === "#" ? 1 : undefined;
+    const hashIndex = moduleSpec.indexOf('#', isSubpathImport);
 
     if (hashIndex === -1) {
       customImportNodes[name] = new ModuleReferenceNode(moduleSpec);


### PR DESCRIPTION
Node.js supports [subpath imports](https://nodejs.org/api/packages.html#subpath-imports), which are module specifiers starting with `#` that map to internal package paths.

The current code incorrectly parsed custom imports like `MyType: '#internal/types#NamedExport'` by finding the first '#' at position 0 when looking for named export delimiters, treating the entire string as a module path.

This pull request fixes this issue.