### PR TITLE
Add support for 'timetz' type in PostgresAdapter

### DIFF
--- a/src/generator/dialects/postgres/postgres-adapter.ts
+++ b/src/generator/dialects/postgres/postgres-adapter.ts
@@ -53,12 +53,7 @@ export class PostgresAdapter extends Adapter {
         new IdentifierNode('IPostgresInterval'),
         new IdentifierNode('number'),
         new IdentifierNode('string'),
-      ]),
-      new UnionExpressionNode([
-        new IdentifierNode('IPostgresInterval'),
-        new IdentifierNode('number'),
-        new IdentifierNode('string'),
-      ]),
+      ])
     ),
     Json: JSON_DEFINITION,
     JsonArray: JSON_ARRAY_DEFINITION,

--- a/src/generator/dialects/postgres/postgres-adapter.ts
+++ b/src/generator/dialects/postgres/postgres-adapter.ts
@@ -125,6 +125,7 @@ export class PostgresAdapter extends Adapter {
     polygon: new IdentifierNode('string'),
     text: new IdentifierNode('string'),
     time: new IdentifierNode('string'),
+    timetz: new IdentifierNode('string'),
     timestamp: new IdentifierNode('Timestamp'),
     timestamptz: new IdentifierNode('Timestamp'),
     tsquery: new IdentifierNode('string'),

--- a/src/generator/dialects/postgres/postgres-adapter.ts
+++ b/src/generator/dialects/postgres/postgres-adapter.ts
@@ -53,7 +53,12 @@ export class PostgresAdapter extends Adapter {
         new IdentifierNode('IPostgresInterval'),
         new IdentifierNode('number'),
         new IdentifierNode('string'),
-      ])
+      ]),
+      new UnionExpressionNode([
+        new IdentifierNode('IPostgresInterval'),
+        new IdentifierNode('number'),
+        new IdentifierNode('string'),
+      ]),
     ),
     Json: JSON_DEFINITION,
     JsonArray: JSON_ARRAY_DEFINITION,


### PR DESCRIPTION
Hey @RobinBlomberg ,

I was trying out the new type-mapping (which works great) but we're missing a valid Postgres TimeTZ type that prevents overriding the type.