### PR TITLE
fix: allow mysql column enum values to be generated as runtime enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Print the generated output to the terminal instead of a file.
 
 #### --runtime-enums <!-- omit from toc -->
 
-The PostgreSQL `--runtime-enums` option generates runtime enums instead of string unions. You can optionally specify which naming convention to use for runtime enum keys. (values: [`pascal-case`, `screaming-snake-case`], default: `screaming-snake-case`)
+For the PostgreSQL and MySQL `--runtime-enums` option generates runtime enums instead of string unions. You can optionally specify which naming convention to use for runtime enum keys. (values: [`pascal-case`, `screaming-snake-case`], default: `screaming-snake-case`)
 
 **Examples:**
 

--- a/src/generator/transformer/transformer.ts
+++ b/src/generator/transformer/transformer.ts
@@ -355,7 +355,7 @@ const transformColumn = ({
     return node;
   }
 
-  let args = transformColumnToArgs(column, context);
+  let args = transformColumnToArgs(column, context, table);
 
   if (column.isArray) {
     const unionizedArgs = unionize(args);
@@ -387,6 +387,7 @@ const transformColumn = ({
 const transformColumnToArgs = (
   column: ColumnMetadata,
   context: TransformContext,
+  table: TableMetadata,
 ) => {
   const dataType = column.dataType.toLowerCase();
 
@@ -438,10 +439,14 @@ const transformColumnToArgs = (
 
   const enumValues = context.enums.get(dataTypeId);
 
-  if (enumValues) {
+  if (enumValues && column.enumValues) {
     if (context.runtimeEnums) {
+      const tableName = table.name;
+      const columnName = column.name;
+      const symbolId = `${tableName}_${columnName}`;
+
       const symbol: SymbolNode = {
-        node: new RuntimeEnumDeclarationNode(symbolId, enumValues, {
+        node: new RuntimeEnumDeclarationNode(symbolId, column.enumValues, {
           identifierStyle:
             context.runtimeEnums === 'screaming-snake-case'
               ? 'screaming-snake-case'
@@ -470,6 +475,25 @@ const transformColumnToArgs = (
   }
 
   if (column.enumValues) {
+    if (context.runtimeEnums) {
+      const tableName = table.name;
+      const columnName = column.name;
+      const symbolId = `${tableName}_${columnName}`;
+
+      const symbol: SymbolNode = {
+        node: new RuntimeEnumDeclarationNode(symbolId, column.enumValues, {
+          identifierStyle:
+            context.runtimeEnums === 'screaming-snake-case'
+              ? 'screaming-snake-case'
+              : 'kysely-pascal-case',
+        }),
+        type: 'RuntimeEnumDefinition',
+      };
+      symbol.node.id.name = context.symbols.set(symbolId, symbol);
+      const node = new IdentifierNode(symbol.node.id.name);
+      return [node];
+    }
+
     return transformEnum(column.enumValues);
   }
 

--- a/src/introspector/dialects/mysql/mysql-introspector.ts
+++ b/src/introspector/dialects/mysql/mysql-introspector.ts
@@ -26,7 +26,7 @@ export class MysqlIntrospector extends Introspector<MysqlDB> {
             : null,
       })),
     }));
-    return new DatabaseMetadata({ tables });
+    return new DatabaseMetadata({ enums, tables });
   }
 
   async introspect(options: IntrospectOptions<MysqlDB>) {


### PR DESCRIPTION
First of all, thank you for the helpful package! Got the issue with runtimeEnums flags, found two places where it's not behaving right. Feel free to comment if something is not right here.