### PR TITLE
feat(generator): Add support for generate symbol with CJK character

### DIFF
--- a/src/generator/transformer/symbol-collection.ts
+++ b/src/generator/transformer/symbol-collection.ts
@@ -82,7 +82,8 @@ export class SymbolCollection {
       this.identifierStyle === 'screaming-snake-case'
         ? toScreamingSnakeCase
         : toKyselyPascalCase;
-    symbolName = caseConverter(id.replaceAll(/[^\w$]/g, '_'));
+    //                                             Add CJK unicode range
+    symbolName = caseConverter(id.replaceAll(/[^\w$\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/g, '_'));
 
     if (symbolNames.has(symbolName)) {
       let suffix = 2;


### PR DESCRIPTION
In regions using Chinese, Japanese, and Korean languages, CJK characters are occasionally used as table names in databases. Filtering out these characters during interface generation could make the interfaces difficult to understand. Currently, TypeScript also supports using these Unicode characters as identifiers. Therefore, I believe these characters can be retained rather than filtered out.