### PR TITLE
Add jsdoc comments for table comments

### DIFF
--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -297,10 +297,18 @@ describe(Cli.name, () => {
           status: CliStatus | null;
         }
 
+        /**
+         * @enum
+         */
         export interface Enum {
           name: string;
         }
 
+        /**
+         * This is a comment on a table.
+         *
+         * It spans multiple lines.
+         */
         export interface FooBar {
           array: string[] | null;
           childDomain: number | null;

--- a/src/generator/ast/interface-declaration-node.ts
+++ b/src/generator/ast/interface-declaration-node.ts
@@ -3,11 +3,17 @@ import type { ObjectExpressionNode } from './object-expression-node';
 
 export class InterfaceDeclarationNode {
   readonly body: ObjectExpressionNode;
+  readonly comment: string | null;
   readonly id: IdentifierNode;
   readonly type = 'InterfaceDeclaration';
 
-  constructor(name: IdentifierNode, body: ObjectExpressionNode) {
+  constructor(
+    name: IdentifierNode,
+    body: ObjectExpressionNode,
+    comment: string | null = null,
+  ) {
     this.id = name;
     this.body = body;
+    this.comment = comment;
   }
 }

--- a/src/generator/generator/serializer.test.ts
+++ b/src/generator/generator/serializer.test.ts
@@ -399,6 +399,42 @@ describe(TypeScriptSerializer.name, () => {
       );
     });
 
+    it('should serialize table comments as a JSDoc above the interface', () => {
+      const dialect = new PostgresDialect();
+      const enums = new EnumCollection();
+
+      const ast = transform({
+        camelCase: true,
+        dialect,
+        metadata: new DatabaseMetadata({
+          enums,
+          tables: [
+            new TableMetadata({
+              columns: [new ColumnMetadata({ dataType: 'int4', name: 'id' })],
+              comment: 'Users of the system.\nSee docs for more.',
+              name: 'users',
+              schema: 'public',
+            }),
+          ],
+        }),
+      });
+
+      strictEqual(
+        serializer.serializeStatements(ast),
+        '/**\n' +
+          ' * Users of the system.\n' +
+          ' * See docs for more.\n' +
+          ' */\n' +
+          'export interface Users {\n' +
+          '  id: number;\n' +
+          '}\n' +
+          '\n' +
+          'export interface DB {\n' +
+          '  users: Users;\n' +
+          '}\n',
+      );
+    });
+
     it('should serialize Postgres JSON fields properly', () => {
       const dialect = new PostgresDialect();
       const enums = new EnumCollection();

--- a/src/generator/generator/serializer.ts
+++ b/src/generator/generator/serializer.ts
@@ -119,6 +119,13 @@ export class TypeScriptSerializer implements Serializer {
   serializeExportStatement(node: ExportStatementNode) {
     let data = '';
 
+    if (
+      node.argument.type === 'InterfaceDeclaration' &&
+      node.argument.comment
+    ) {
+      data += this.serializeJsdoc(node.argument.comment);
+    }
+
     data += 'export ';
 
     switch (node.argument.type) {
@@ -329,6 +336,18 @@ export class TypeScriptSerializer implements Serializer {
     }
 
     data += '}';
+
+    return data;
+  }
+
+  serializeJsdoc(comment: string) {
+    let data = '/**\n';
+
+    for (const line of comment.split(/\r?\n/)) {
+      data += ` *${line ? ` ${line}` : ''}\n`;
+    }
+
+    data += ' */\n';
 
     return data;
   }

--- a/src/generator/generator/snapshots/postgres.snapshot.ts
+++ b/src/generator/generator/snapshots/postgres.snapshot.ts
@@ -40,10 +40,18 @@ export type TestStatus = "ABC_DEF" | "GHI_JKL";
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
+/**
+ * @enum
+ */
 export interface Enum {
   name: string;
 }
 
+/**
+ * This is a comment on a table.
+ *
+ * It spans multiple lines.
+ */
 export interface FooBar {
   array: string[] | null;
   childDomain: number | null;

--- a/src/generator/generator/snapshots/postgres2.snapshot.ts
+++ b/src/generator/generator/snapshots/postgres2.snapshot.ts
@@ -46,10 +46,18 @@ export type Numeric = ColumnType<number | string>;
 
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
+/**
+ * @enum
+ */
 export interface Enum {
   name: string;
 }
 
+/**
+ * This is a comment on a table.
+ *
+ * It spans multiple lines.
+ */
 export interface FooBar {
   array: string[] | null;
   childDomain: number | null;

--- a/src/generator/transformer/transformer.ts
+++ b/src/generator/transformer/transformer.ts
@@ -523,6 +523,7 @@ const transformTables = (context: TransformContext) => {
       new InterfaceDeclarationNode(
         new TableIdentifierNode(symbolName),
         expression,
+        table.comment,
       ),
     );
     tableNodes.push(tableNode);

--- a/src/generator/transformer/transformer.type-mapping.test.ts
+++ b/src/generator/transformer/transformer.type-mapping.test.ts
@@ -34,6 +34,7 @@ describe('transform with type mapping', () => {
     columns: ColumnMetadata[],
   ): TableMetadata => ({
     columns,
+    comment: null,
     isPartition: false,
     isView: false,
     name,

--- a/src/introspector/dialects/mysql/mysql-db.ts
+++ b/src/introspector/dialects/mysql/mysql-db.ts
@@ -5,4 +5,9 @@ export type MysqlDB = {
     TABLE_NAME: string;
     TABLE_SCHEMA: string;
   };
+  'information_schema.TABLES': {
+    TABLE_COMMENT: string | null;
+    TABLE_NAME: string;
+    TABLE_SCHEMA: string;
+  };
 };

--- a/src/introspector/dialects/mysql/mysql-introspector.ts
+++ b/src/introspector/dialects/mysql/mysql-introspector.ts
@@ -11,13 +11,16 @@ const ENUM_REGEXP = /^enum\(.*\)$/;
 export class MysqlIntrospector extends Introspector<MysqlDB> {
   createDatabaseMetadata({
     enums,
+    tableComments,
     tables: rawTables,
   }: {
     enums: EnumCollection;
+    tableComments: Map<string, string>;
     tables: KyselyTableMetadata[];
   }) {
     const tables = rawTables.map((table) => ({
       ...table,
+      comment: tableComments.get(`${table.schema ?? ''}.${table.name}`) ?? null,
       columns: table.columns.map((column) => ({
         ...column,
         enumValues:
@@ -30,9 +33,12 @@ export class MysqlIntrospector extends Introspector<MysqlDB> {
   }
 
   async introspect(options: IntrospectOptions<MysqlDB>) {
-    const tables = await this.getTables(options);
-    const enums = await this.introspectEnums(options.db);
-    return this.createDatabaseMetadata({ enums, tables });
+    const [tables, enums, tableComments] = await Promise.all([
+      this.getTables(options),
+      this.introspectEnums(options.db),
+      this.introspectTableComments(options.db),
+    ]);
+    return this.createDatabaseMetadata({ enums, tableComments, tables });
   }
 
   async introspectEnums(db: Kysely<MysqlDB>) {
@@ -54,5 +60,27 @@ export class MysqlIntrospector extends Introspector<MysqlDB> {
     }
 
     return enums;
+  }
+
+  async introspectTableComments(db: Kysely<MysqlDB>) {
+    const rows = await db
+      .withoutPlugins()
+      .selectFrom('information_schema.TABLES')
+      .select(['TABLE_SCHEMA', 'TABLE_NAME', 'TABLE_COMMENT'])
+      .where('TABLE_COMMENT', '<>', '')
+      .execute();
+
+    const tableComments = new Map<string, string>();
+
+    for (const row of rows) {
+      if (row.TABLE_COMMENT) {
+        tableComments.set(
+          `${row.TABLE_SCHEMA}.${row.TABLE_NAME}`,
+          row.TABLE_COMMENT,
+        );
+      }
+    }
+
+    return tableComments;
   }
 }

--- a/src/introspector/dialects/postgres/postgres-introspector.ts
+++ b/src/introspector/dialects/postgres/postgres-introspector.ts
@@ -50,11 +50,13 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
     domains,
     enums,
     partitions,
+    tableComments,
     tables: rawTables,
   }: {
     domains: PostgresDomainInspector[];
     enums: EnumCollection;
     partitions: TableReference[];
+    tableComments: Map<string, string>;
     tables: KyselyTableMetadata[];
   }) {
     const tables = rawTables
@@ -87,6 +89,7 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
 
         return {
           columns,
+          comment: tableComments.get(`${table.schema}.${table.name}`) ?? null,
           isPartition,
           isView: table.isView,
           name: table.name,
@@ -114,14 +117,21 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
   }
 
   async introspect(options: IntrospectOptions<PostgresDB>) {
-    const [tables, domains, enums, partitions, materializedViews] =
-      await Promise.all([
-        this.getTables(options),
-        this.introspectDomains(options.db),
-        this.introspectEnums(options.db),
-        this.introspectPartitions(options.db),
-        this.introspectMaterializedViews(options),
-      ]);
+    const [
+      tables,
+      domains,
+      enums,
+      partitions,
+      materializedViews,
+      tableComments,
+    ] = await Promise.all([
+      this.getTables(options),
+      this.introspectDomains(options.db),
+      this.introspectEnums(options.db),
+      this.introspectPartitions(options.db),
+      this.introspectMaterializedViews(options),
+      this.introspectTableComments(options.db),
+    ]);
 
     const allTables = [...tables, ...materializedViews];
 
@@ -129,8 +139,34 @@ export class PostgresIntrospector extends Introspector<PostgresDB> {
       enums,
       domains,
       partitions,
+      tableComments,
       tables: allTables,
     });
+  }
+
+  async introspectTableComments(db: Kysely<PostgresDB>) {
+    const result = await sql<{
+      schema: string;
+      name: string;
+      comment: string;
+    }>`
+      select
+        n.nspname as schema,
+        c.relname as name,
+        obj_description(c.oid, 'pg_class') as comment
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where c.relkind in ('r', 'v', 'm', 'p', 'f')
+        and obj_description(c.oid, 'pg_class') is not null;
+    `.execute(db);
+
+    const tableComments = new Map<string, string>();
+
+    for (const row of result.rows) {
+      tableComments.set(`${row.schema}.${row.name}`, row.comment);
+    }
+
+    return tableComments;
   }
 
   async introspectDomains(db: Kysely<PostgresDB>) {

--- a/src/introspector/introspector.fixtures.ts
+++ b/src/introspector/introspector.fixtures.ts
@@ -112,6 +112,12 @@ const up = async (db: Kysely<any>, dialect: IntrospectorDialect) => {
       .addColumn('name', 'text', (col) => col.primaryKey().notNull())
       .execute();
     await db.executeQuery(sql`comment on table enum is '@enum';`.compile(db));
+    await db.executeQuery(
+      sql`
+        comment on table foo_bar is
+        'This is a comment on a table.\r\n\r\nIt spans multiple lines.';
+      `.compile(db),
+    );
     await db.schema
       .alterTable('foo_bar')
       .addColumn('enum', sql`text not null references enum(name)`)

--- a/src/introspector/introspector.test.ts
+++ b/src/introspector/introspector.test.ts
@@ -165,6 +165,7 @@ describe(Introspector.name, () => {
                     name: 'name',
                   }),
                 ],
+                comment: '@enum',
                 name: 'enum',
                 schema: 'public',
               }),
@@ -302,6 +303,8 @@ describe(Introspector.name, () => {
                     name: 'enum',
                   }),
                 ],
+                comment:
+                  'This is a comment on a table.\r\n\r\nIt spans multiple lines.',
                 name: 'foo_bar',
                 schema: 'public',
               }),

--- a/src/introspector/metadata/table-metadata.ts
+++ b/src/introspector/metadata/table-metadata.ts
@@ -3,6 +3,7 @@ import { ColumnMetadata } from './column-metadata';
 
 export type TableMetadataOptions = {
   columns: ColumnMetadataOptions[];
+  comment?: string | null;
   isPartition?: boolean;
   isView?: boolean;
   name: string;
@@ -11,6 +12,7 @@ export type TableMetadataOptions = {
 
 export class TableMetadata {
   columns: ColumnMetadata[];
+  comment: string | null;
   isPartition: boolean;
   isView: boolean;
   name: string;
@@ -18,6 +20,7 @@ export class TableMetadata {
 
   constructor(options: TableMetadataOptions) {
     this.columns = options.columns.map((column) => new ColumnMetadata(column));
+    this.comment = options.comment ?? null;
     this.isPartition = !!options.isPartition;
     this.isView = !!options.isView;
     this.name = options.name;


### PR DESCRIPTION
## Summary

Generate JSDoc comments above table interfaces using table-level comments from the database, mirroring the existing column-comment behavior added in #127.

Closes #247.
Closes #292.

- Adds an optional `comment` field to `TableMetadata`.
- Postgres: new `introspectTableComments` query against `obj_description(pg_class.oid, 'pg_class')` for `relkind in ('r','v','m','p','f')`. Covers regular tables, views, materialized views, partitioned and foreign tables.
- MySQL: new `introspectTableComments` query against `information_schema.TABLES.TABLE_COMMENT`.
- Threads the comment through the transformer onto `InterfaceDeclarationNode`, and emits a JSDoc block above `export interface Foo` in the serializer.
- SQLite, libsql, and MSSQL are unchanged (no native table-comment support in their existing introspectors).

### Example

For `COMMENT ON TABLE foo_bar IS 'This is a comment on a table.';`:

```ts
/**
 * This is a comment on a table.
 */
export interface FooBar {
  // ...
}
```

Multi-line comments are preserved.

## Test plan

- [x] `pnpm check:types`
- [x] `pnpm test` (introspector, generator, serializer, CLI suites)
- [x] Fixture extended with a multi-line `COMMENT ON TABLE foo_bar`; assertion
      added in `introspector.test.ts`
- [x] New serializer unit test for the table-level JSDoc
- [x] Postgres snapshots (`postgres.snapshot.ts`, `postgres2.snapshot.ts`) and the CLI test's expected output updated