### PR TITLE
allow tedious 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "mysql2": ">=2.3.3 <4.0.0",
     "pg": ">=8.8.0 <9.0.0",
     "tarn": ">=3.0.0 <4.0.0",
-    "tedious": ">=18.0.0 <20.0.0"
+    "tedious": ">=18.0.0 <21.0.0"
   },
   "peerDependenciesMeta": {
     "@libsql/kysely-libsql": {
@@ -178,7 +178,7 @@
         1,
         {
           "checkGlobalVariables": false
-        }
+        }te
       ],
       "unicorn/prefer-node-protocol": 0
     }


### PR DESCRIPTION
https://github.com/tediousjs/tedious/releases/tag/v20.0.0
Tedious 20 has been released 2 weeks ago and the only change is in node version support. I think it's safe to allow tedious 20 as a peer dependency. No testing was made by me though.